### PR TITLE
Initial changes

### DIFF
--- a/.azurepipelines/BuildAndTest.yml
+++ b/.azurepipelines/BuildAndTest.yml
@@ -1,0 +1,88 @@
+## @file
+# Azure Pipeline build file to build and test code in this repo.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+trigger:
+- main
+
+pr:
+- main
+
+resources:
+  repositories:
+    - repository: mu_devops
+      type: github
+      endpoint: microsoft
+      name: microsoft/mu_devops
+      ref: main
+
+parameters:
+  - name: matrix
+    type: object
+    default:
+      Linux:
+        ImageName: ubuntu-latest
+        ContainerImage: ghcr.io/microsoft/mu_devops/ubuntu-22-build:latest
+      Windows:
+        ImageName: windows-latest
+
+variables:
+- group: coverage
+
+jobs:
+  - ${{ each item in parameters.matrix }}:
+    - job: BuildAndTest_${{ item.Key }}
+      displayName: Build and Test ${{ item.Key }}
+
+      pool:
+        vmImage: ${{ item.Value.ImageName }}
+
+      ${{ if item.Value.ContainerImage }}:
+        container:
+          image: ${{ item.Value.ContainerImage }}
+          options: --user root --name mu_devops_build_container --security-opt seccomp=unconfined
+
+      workspace:
+        clean: all
+
+      steps:
+      - checkout: self
+        fetchDepth: 1
+        clean: true
+
+      # Only run on Windows since it does not use a container and can
+      # depend on a wider toolset provided in the VM image.
+      - ${{ if eq(item.Value.ImageName, 'windows-latest') }}:
+        - template: Steps/InstallMarkdownLint.yml@mu_devops
+        - template: Steps/RunMarkdownLint.yml@mu_devops
+        - template: Steps/InstallSpellCheck.yml@mu_devops
+        - template: Steps/RunSpellCheck.yml@mu_devops
+          parameters:
+            spell_check_parameters: "-c cspell.json **/*.md **/*.py **/*.rs"
+      - template: Steps/RustSetupSteps.yml@mu_devops
+      - template: Steps/RustCargoSteps.yml@mu_devops
+        parameters:
+          test_command: "cargo tarpaulin --all --out xml --output-dir $(Build.StagingDirectory)"
+          build_command: "cargo build"
+      - task: PythonScript@0
+        displayName: Rename coverage file
+        env:
+          OUTPUT_DIR: $(Build.StagingDirectory)
+        inputs:
+          scriptSource: inline
+          script: |
+            import os
+            import pathlib
+
+            OUTPUT_DIR = os.environ['OUTPUT_DIR']
+            original = pathlib.Path(OUTPUT_DIR, 'cobertura.xml')
+            new = pathlib.Path(OUTPUT_DIR, 'coverage.xml')
+            original.replace(new)
+
+      - template: Steps/UploadCodeCoverage.yml@mu_devops
+        parameters:
+          report_dir: $(Build.StagingDirectory)
+          install_dependencies: false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+* text eol=crlf
+*.Fv binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,21 @@
+## @file
+# markdownlint configuration
+#
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+# Rules can be found here: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+# Config info: https://github.com/DavidAnson/markdownlint#configuration
+
+{
+  "default": true,
+  "MD013": {"line_length": 120, "code_blocks": false, "tables": false},
+  "MD033": {"allowed_elements": ["br"]}
+}

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,8 @@
+# Ignore build directory
+/Build/
+
+# Ignore external dependencies
+*_extdep/
+
+# Ignore submdules
+/Common

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing to Project Mu
+
+Welcome, and thank you for your interest in contributing to Project Mu!
+
+There are many ways in which you can contribute, beyond writing code. The goal of this document is to provide a
+high-level overview of how you can get involved.
+
+If this is your first time working with Project Mu, please keep in mind that many project details are maintained in
+the [Project Mu Documentation](https://microsoft.github.io/mu/).
+
+## Asking Questions
+
+Have a question? Rather than opening an issue, please post your question under the `Q&A` category in the `Discussions`
+section of the relevant Project Mu GitHub repo.
+
+## Reporting Issues
+
+Every Project Mu repo has an `Issues` section. Bug reports, feature requests, and documentation requests can all be
+submitted in the issues section.
+
+## Security Vulnerabilities
+
+Please review the repos `Security Policy` but in general every Project Mu repo has `Private vulnerability reporting`
+enabled.  Please use the security tab to report a potential issue.
+
+### Identify Where to Report
+
+Project Mu is distributed across multiple repositories. Use features such as issues and discussions in the repository
+most relevant to the topic.
+
+Although we prefer items to be filed in the most relevant repo, if you're unsure which repo is most relevant, the item
+can be filed in the [Project Mu Documentation Repo](https://github.com/microsoft/mu) and we will review the request and
+move it to the relevant repo if necessary.
+
+### Look For an Existing Issue
+
+Before you create a new issue, please do a search in the issues section of the relevant repo to see if the issue or
+feature request has already been filed.
+
+If you find your issue already exists, make relevant comments and add your
+[reaction](https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments). Use a reaction in place
+of a "+1" comment:
+
+* 👍 - upvote
+* 👎 - downvote
+
+If you cannot find an existing issue that describes your bug or feature, create a new issue using the guidelines below.
+
+### Follow Your Issue
+
+Please continue to follow your request after it is submitted to assist with any additional information that might be
+requested.
+
+### Pull Request Best Practices
+
+Pull requests for UEFI code can become large and difficult to review due to the large number of build and
+configuration files. To aid maintainers in reviewing your code, we suggest adhering to the following guidelines:
+
+1. Do keep code reviews single purpose; don't add more than one feature at a time.
+2. Do fix bugs independently of adding features.
+3. Do provide documentation and unit tests.
+4. Do introduce code in digestible amounts.
+   * If the contribution logically be broken up into separate pull requests that independently build and function
+     successfully, do use multiple pull requests.
+
+#### Code Categories
+
+To keep code digestible, you may consider breaking large pull requests into three categories of commits within the pull
+request.
+
+1. **Interfaces**: .h, .inf, .dec, documentation
+2. **Implementation**: .c, unit tests, unit test build file; unit tests should build and run at this point
+3. **Integration/Build**: .dec, .dsc, .fdf, (.yml) configuration files, integration tests; code added to platform and
+   affects downstream consumers
+
+By breaking the pull request into these three categories, the pull request reviewers can digest each piece
+independently.
+
+If your commits are still very large after adhering to these categories, consider further breaking the pull request
+down by library/driver; break each component into its own commit.
+
+#### Implementation Limits
+
+Implementation is ultimately composed of functions as logical units of code.
+
+To help maintainers review the code and improve long-term maintainability, limit functions to 60 lines of code. If your
+function exceeds 60 lines of code, it likely has also exceeded a single responsibility and should be broken up.
+
+Files are easier to review and maintain if they contain functions that serves similar purpose. Limit files to around
+1,000 lines of code (excluding comments). If your file exceeds 1,000 lines of code, it may have functions that should
+be split into separate files.
+
+---
+
+By following these guidelines, your pull requests will be reviewed faster, and you'll avoid being asked to refactor the
+code to follow the guidelines.
+
+Feel free to create a draft pull request and ask for suggestions on how to split the pull request if you are unsure.
+
+## Thank You
+
+Thank you for your interest in Project Mu and taking the time to contribute!

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "mu_pi"
+version = "0.1.0"
+edition = "2021"
+license = "BSD-2-Clause-Patent"
+description = "Platform Initialization (PI) Specification definitions and support code in Rust."
+repository = "https://github.com/microsoft/mu_rust_pi"
+readme = "Readme.md"
+rust-version = "1.68"
+keywords = ["firmware", "mu", "pi", "uefi"]
+categories = ["embedded", "hardware-support", "no-std"]
+
+[dependencies]
+indoc = "2.0"
+num-traits = { version = "0.2", default-features = false }
+r-efi = { version = "4.4.0", default_features = false }
+uuid = { version = "1.8", default_features = false }
+
+[dev-dependencies]
+serde = { version = "1.0.197", features = ["derive"]}
+serde_yaml = "0.9.34"

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,4 @@
-    MIT License
+BSD-2-Clause-Patent License
 
-    Copyright (c) Microsoft Corporation.
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in all
-    copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE
+Copyright (C) Microsoft Corporation. All rights reserved.
+SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/README.md
+++ b/README.md
@@ -1,1 +1,85 @@
-TODO: Create a file called LICENSE (not LICENSE.TXT, LICENSE.md, etc.)…
+# Mu Rust Platform Initialization (PI)
+
+Platform Initialization (PI) Specification definitions and support code in rust.
+
+This repository is part of [Project Mu](https://microsoft.github.io/mu).
+
+## Requirements
+
+- rustc >= 1.68.0
+
+## Build
+
+```sh
+cargo build
+```
+
+### Build with Official Toolchains
+
+These instructions are derived from those in [r-efi](https://github.com/r-efi/r-efi/blob/main/README.md).
+
+Starting with rust-version 1.68, rustup distributes pre-compiled toolchains for many UEFI targets. You can enumerate
+and install them via `rustup`. This example shows how to enumerate all available targets for your stable toolchain
+and then install the UEFI target for the `x86_64` architecture:
+
+```sh
+rustup target list --toolchain=stable
+rustup target add --toolchain=stable x86_64-unknown-uefi
+```
+
+This project can then be compiled directly for the selected target:
+
+```sh
+cargo +stable build --lib --target x86_64-unknown-uefi
+```
+
+### Build via Foreign Targets
+
+The project can be built for non-UEFI targets via the standard rust toolchains. This allows non-UEFI targets to
+interact with UEFI systems or otherwise host UEFI operations. Furthermore, this allows running the foreign test-suite
+of this project as long as the target supports the full standard library:
+
+```sh
+cargo +stable build --all-targets
+cargo +stable test --all-targets
+```
+
+## Test
+
+```sh
+cargo test
+```
+
+## Contributing
+
+Contributions are always welcome and encouraged!
+
+Please run the following commands before creating a pull request:
+
+- \>`cargo fmt`
+- \>`cargo test --all`
+  - Verify tests pass.
+- \>`cargo doc --open`
+  - Verify documentation appearance.
+
+Guidance and requirements:
+
+- [Contribution Guidance](https://microsoft.github.io/mu/How/contributing/).
+- [Code Requirements](https://microsoft.github.io/mu/CodeDevelopment/requirements/)
+- [Doc Requirements](https://microsoft.github.io/mu/CodeDevelopment/rust_documentation_conventions/)
+
+## Issues
+
+Please open any issues in the [issues section](https://github.com/microsoft/mu_rust_hid/issues).
+
+## Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com). with any additional questions or comments.
+
+## Copyright & License
+
+- Copyright (c) Microsoft Corporation
+- SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,34 +1,34 @@
-<!-- BEGIN MICROSOFT SECURITY.MD V0.0.9 BLOCK -->
+# Project Mu Security Policy
 
-## Security
+Project Mu is an open source firmware project that is leveraged by and combined into
+other projects to build the firmware for a given product.  We build and maintain this
+code with the intent that any consuming projects can use this code as-is.  If features
+or fixes are necessary we ask that they contribute them back to the project.  **But**, that
+said, in the firmware ecosystem there is a lot of variation and differentiation, and
+the license in this project allows flexibility for use without contribution back to
+Project Mu. Therefore, any issues found here may or may not exist in products using Project Mu.
 
-Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet) and [Xamarin](https://github.com/xamarin).
+## Supported Versions
 
-If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://aka.ms/security.md/definition), please report it to us as described below.
+Due to the usage model we generally only supply fixes to the most recent release branch (or main).
+For a serious vulnerability we may patch older release branches.
 
-## Reporting Security Issues
+## Additional Notes
+
+Project Mu contains code that is available and/or originally authored in other
+repositories (see <https://github.com/tianocore/edk2> as one such example).  For any
+vulnerability found, we may be subject to their security policy and may need to work
+with those groups to resolve amicably and patch the "upstream".  This might involve
+additional time to release and/or additional confidentiality requirements.
+
+## Reporting a Vulnerability
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://aka.ms/security.md/msrc/create-report).
+Instead please use **Github Private vulnerability reporting**, which is enabled for each Project Mu
+repository. This process is well documented by github in their documentation [here](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability).
 
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/security.md/msrc/pgp).
-
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc). 
-
-Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
-
-  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
-  * Full paths of source file(s) related to the manifestation of the issue
-  * The location of the affected source code (tag/branch/commit or direct URL)
-  * Any special configuration required to reproduce the issue
-  * Step-by-step instructions to reproduce the issue
-  * Proof-of-concept or exploit code (if possible)
-  * Impact of the issue, including how an attacker might exploit the issue
-
-This information will help us triage your report more quickly.
-
-If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://aka.ms/security.md/msrc/bounty) page for more details about our active programs.
+This process will allow us to privately discuss the issue, collaborate on a solution, and then disclose the vulnerability.
 
 ## Preferred Languages
 
@@ -36,6 +36,4 @@ We prefer all communications to be in English.
 
 ## Policy
 
-Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://aka.ms/security.md/cvd).
-
-<!-- END MICROSOFT SECURITY.MD BLOCK -->
+Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://www.microsoft.com/en-us/msrc/cvd).

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,37 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "dictionaries": [
+      "companies ",
+      "softwareTerms",
+      "python",
+      "rust"
+  ],
+  "ignorePaths": [
+      "*.pdb",
+      "**/*_extdep/**",
+      "*.pdf",
+      "*.exe",
+      "*.jpg"
+  ],
+  "minWordLength": 5,
+  "allowCompoundWords": true,
+  "maxNumberOfProblems": 200,
+  "maxDuplicateProblems": 200,
+  "ignoreWords": [
+  ],
+  "words": [
+    "aarch",
+    "depex",
+    "dxefv",
+    "efiapi",
+    "eficall",
+    "indoc",
+    "rustc",
+    "rustfmt",
+    "uefi's",
+    "uncacheable",
+    "upvote",
+    "xffff"
+  ]
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.77.1"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,21 @@
+# rustfmt (and cargo fmt) will automatically pick up this config when run in the workspace.
+
+# Note that some items are included here set to their default values. This is to explicitly
+# reveal settings for more common options.
+
+# Keep these options sorted in ascending order to ease lookup with rustfmt documentation.
+
+edition = "2021"              # This would normally be picked up from Cargo.toml if not specified here
+force_explicit_abi = true     # Always print the ABI for extern items (e.g. extern {... will become extern "C" {...)
+hard_tabs = false             # Always uses spaces for indentation and alignment
+max_width = 120               # The maximum width of each line
+merge_derives = false         # Do not merge derives into a single line (leave to author discretion).
+imports_granularity = "Crate" # Merge imports from a single crate into separate statements.
+newline_style = "Windows"     # Always use Windows line endings '\r\n'
+reorder_impl_items = false    # Do not force where type and const before macros and methods in impl blocks.
+reorder_imports = true        # Do reorder import and extern crate statements alphabetically for readability.
+reorder_modules = true        # Do reorder mod declarations alphabetically for readability.
+tab_spaces = 2                # Use 2 spaces for indentation (Rust default is 4).
+unstable_features = false     # Do not use unstable rustfmt features.
+use_small_heuristics = "Max"  # Set all granular width settings to the same as max_width (do not use heuristics)
+wrap_comments = false         # Leave comment formatting to author's discretion

--- a/src/address_helper.rs
+++ b/src/address_helper.rs
@@ -1,0 +1,105 @@
+//! Helper functions related to address manipulation.
+//!
+//! Portions derived from the x86_64 crate addr.rs file.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+/// Align address downwards.
+///
+/// Returns the greatest `x` with alignment `align` so that `x <= addr`.
+///
+/// Panics if the alignment is not a power of two.
+#[inline]
+pub const fn align_down(addr: u64, align: u64) -> u64 {
+  assert!(align.is_power_of_two(), "`align` must be a power of two");
+  addr & !(align - 1)
+}
+
+/// Align address upwards.
+///
+/// Returns the smallest `x` with alignment `align` so that `x >= addr`.
+///
+/// Panics if the alignment is not a power of two or if an overflow occurs.
+#[inline]
+pub const fn align_up(addr: u64, align: u64) -> u64 {
+  assert!(align.is_power_of_two(), "`align` must be a power of two");
+  let align_mask = align - 1;
+  if addr & align_mask == 0 {
+    addr // already aligned
+  } else {
+    // FIXME: Replace with .expect, once `Option::expect` is const.
+    if let Some(aligned) = (addr | align_mask).checked_add(1) {
+      aligned
+    } else {
+      panic!("attempt to add with overflow")
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::address_helper::{align_down, align_up};
+
+  #[test]
+  #[should_panic]
+  fn align_down_align_panic() {
+    // alignment is not a power of 2
+    align_down(0, 0x0);
+  }
+
+  #[test]
+  #[should_panic]
+  fn align_up_align_panic() {
+    // alignment is not a power of 2
+    align_up(0, 0x0);
+  }
+
+  #[test]
+  fn test_align_down() {
+    // align 1
+    assert_eq!(align_down(0, 1), 0);
+    assert_eq!(align_down(1234, 1), 1234);
+    assert_eq!(align_down(0xffff_ffff_ffff_ffff, 1), 0xffff_ffff_ffff_ffff);
+    // align 2
+    assert_eq!(align_down(0, 2), 0);
+    assert_eq!(align_down(1234, 2), 1234);
+    assert_eq!(align_down(0xffff_ffff_ffff_ffff, 2), 0xffff_ffff_ffff_fffe);
+    // address 0
+    assert_eq!(align_down(0, 128), 0);
+    assert_eq!(align_down(0, 1), 0);
+    assert_eq!(align_down(0, 2), 0);
+    assert_eq!(align_down(0, 0x8000_0000_0000_0000), 0);
+
+    // Validate alignment of (align > address) -> 0
+    assert_eq!(align_down(0xFFFF, 0x1000_0000), 0);
+  }
+
+  #[test]
+  fn test_align_up() {
+    // align 1
+    assert_eq!(align_up(0, 1), 0);
+    assert_eq!(align_up(1234, 1), 1234);
+    assert_eq!(align_up(0xffff_ffff_ffff_ffff, 1), 0xffff_ffff_ffff_ffff);
+    // align 2
+    assert_eq!(align_up(0, 2), 0);
+    assert_eq!(align_up(1233, 2), 1234);
+    assert_eq!(align_up(0xffff_ffff_ffff_fffe, 2), 0xffff_ffff_ffff_fffe);
+    // address 0
+    assert_eq!(align_up(0, 128), 0);
+    assert_eq!(align_up(0, 1), 0);
+    assert_eq!(align_up(0, 2), 0);
+    assert_eq!(align_up(0, 0x8000_0000_0000_0000), 0);
+  }
+
+  #[test]
+  #[should_panic]
+  fn test_align_up_overflow() {
+    // causes buffer overflow when checked_add(1) is called
+    align_up(0xffff_ffff_ffff_ffff, 0x1_0000_0000_0000);
+  }
+}

--- a/src/dxe_services.rs
+++ b/src/dxe_services.rs
@@ -1,0 +1,317 @@
+//! DXE Services
+//!
+//! Services used in the DXE boot phase:
+//! - **Global Coherency Domain (GCD) Services** - The Global Coherency Domain (GCD) Services are used to manage the
+//!   memory and I/O resources visible to the boot processor.
+//! - **Dispatcher Services** - Used during preboot to schedule drivers for execution.
+//!
+//! See <https://uefi.org/specs/PI/1.8A/V2_Services_DXE_Services.html#services-dxe-services>.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+use core::ffi::c_void;
+
+use r_efi::{
+  efi::{Guid, Handle, PhysicalAddress, Status},
+  system::TableHeader,
+};
+
+pub const DXE_SERVICES_TABLE_GUID: Guid =
+  Guid::from_fields(0x5ad34ba, 0x6f02, 0x4214, 0x95, 0x2e, &[0x4d, 0xa0, 0x39, 0x8e, 0x2b, 0xb9]);
+
+/// This service adds reserved memory system memory or memory mapped IO resources to the global coherency domain of the processor.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.1
+pub type AddMemorySpace = extern "efiapi" fn(GcdMemoryType, PhysicalAddress, u64, u64) -> Status;
+
+/// This service allocates nonexistent memory reserved memory system memory or memory-mapped IO resources
+/// from the global coherency domain of the processor.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.2
+pub type AllocateMemorySpace =
+  extern "efiapi" fn(GcdAllocateType, GcdMemoryType, u32, u64, *mut PhysicalAddress, Handle, Handle) -> Status;
+
+/// This service frees nonexistent memory, reserved memory, system memory,
+/// or memory-mapped I/O resources from the global coherency domain of the processor.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.3
+pub type FreeMemorySpace = extern "efiapi" fn(PhysicalAddress, u64) -> Status;
+
+/// This service removes reserved memory, system memory,
+/// or memory-mapped I/O resources from the global coherency domain of the processor.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.4
+pub type RemoveMemorySpace = extern "efiapi" fn(PhysicalAddress, u64) -> Status;
+
+/// This service retrieves the descriptor for a memory region containing a specified address.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.5
+pub type GetMemorySpaceDescriptor = extern "efiapi" fn(PhysicalAddress, *mut MemorySpaceDescriptor) -> Status;
+
+/// This service modifies the attributes for a memory region in the global coherency domain of the processor.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.6
+pub type SetMemorySpaceAttributes = extern "efiapi" fn(PhysicalAddress, u64, u64) -> Status;
+
+/// This service modifies the capabilities for a memory region in the global coherency domain of the processor.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.7
+pub type SetMemorySpaceCapabilities = extern "efiapi" fn(PhysicalAddress, u64, u64) -> Status;
+
+/// Returns a map of the memory resources in the global coherency domain of the processor.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.8
+pub type GetMemorySpaceMap = extern "efiapi" fn(*mut usize, *mut *mut MemorySpaceDescriptor) -> Status;
+
+/// This service adds reserved I/O, or I/O resources to the global coherency domain of the processor.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.9
+pub type AddIoSpace = extern "efiapi" fn(GcdIoType, PhysicalAddress, u64) -> Status;
+
+/// This service allocates nonexistent I/O, reserved I/O, or I/O resources from the global coherency domain of the processor.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.10
+pub type AllocateIoSpace =
+  extern "efiapi" fn(GcdAllocateType, GcdIoType, u32, u64, *mut PhysicalAddress, Handle, Handle) -> Status;
+
+/// This service frees nonexistent I/O, reserved I/O, or I/O resources from the global coherency domain of the processor.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.11
+pub type FreeIoSpace = extern "efiapi" fn(PhysicalAddress, u64) -> Status;
+
+/// This service removes reserved I/O, or I/O resources from the global coherency domain of the processor.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.12
+pub type RemoveIoSpace = extern "efiapi" fn(PhysicalAddress, u64) -> Status;
+
+/// This service retrieves the descriptor for an I/O region containing a specified address.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.13
+pub type GetIoSpaceDescriptor = extern "efiapi" fn(PhysicalAddress, *mut IoSpaceDescriptor) -> Status;
+
+/// Returns a map of the I/O resources in the global coherency domain of the processor.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.14
+pub type GetIoSpaceMap = extern "efiapi" fn(*mut usize, *mut *mut IoSpaceDescriptor) -> Status;
+
+/// Loads and executes DXE drivers from firmware volumes.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.3.1
+pub type Dispatch = extern "efiapi" fn() -> Status;
+
+/// Clears the Schedule on Request (SOR) flag for a component that is stored in a firmware volume.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.3.2
+pub type Schedule = extern "efiapi" fn(Handle, *const Guid) -> Status;
+
+/// Promotes a file stored in a firmware volume from the untrusted to the trusted state.
+/// Only the Security Architectural Protocol can place a file in the untrusted state.
+/// A platform specific component may choose to use this service to promote a previously untrusted file to the trusted state.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.3.3
+pub type Trust = extern "efiapi" fn(Handle, *const Guid) -> Status;
+
+/// Creates a firmware volume handle for a firmware volume that is present in system memory.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-7.3. II-59 (This one does not have a section)
+pub type ProcessFirmwareVolume = extern "efiapi" fn(*const c_void, u32, *mut Handle) -> Status;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+/// `EFI_GCD_MEMORY_TYPE` in specification.
+pub enum GcdMemoryType {
+  /// A memory region that is visible to the boot processor.
+  /// However, there are no system components that are currently decoding this memory region.
+  #[default]
+  NonExistent = 0,
+  /// A memory region that is visible to the boot processor.
+  /// This memory region is being decoded by a system component,
+  /// but the memory region is not considered to be either system memory or memory-mapped I/O.
+  Reserved,
+  /// A memory region that is visible to the boot processor.
+  /// A memory controller is currently decoding this memory region
+  /// and the memory controller is producing a tested system memory region that is available to the memory services.
+  SystemMemory,
+  /// A memory region that is visible to the boot processor. This memory region is currently being decoded by a
+  /// component as memory-mapped I/O that can be used to access I/O devices in the platform.
+  MemoryMappedIo,
+  /// A memory region that is visible to the boot processor. This memory supports byte-addressable non-volatility.
+  Persistent,
+  /// A memory region that provides higher reliability relative to other memory in the system.
+  /// If all memory has the same reliability, then this bit is not used.
+  MoreReliable,
+  /// A memory region that is unaccepted. This region must be accepted before it can be converted to system memory.
+  Unaccepted,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
+/// `EFI_GCD_ALLOCATE_TYPE` in specification.
+pub enum GcdAllocateType {
+  #[default]
+  AnySearchBottomUp,
+  MaxAddressSearchBottomUp,
+  Address,
+  AnySearchTopDown,
+  MaxAddressSearchTopDown,
+  MaxAllocateType,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// `EFI_GCD_MEMORY_SPACE_DESCRIPTOR` in specification.
+pub struct MemorySpaceDescriptor {
+  /// The physical address of the first byte in the memory region.
+  pub base_address: PhysicalAddress,
+  /// The number of bytes in the memory region.
+  pub length: u64,
+  /// The bit mask of attributes that the memory region is capable of supporting.
+  pub capabilities: u64,
+  /// The bit mask of attributes that the memory region is currently using.
+  pub attributes: u64,
+  /// Type of the memory region.
+  pub memory_type: GcdMemoryType,
+  /// The image handle of the agent that allocated the memory resource described by PhysicalStart and NumberOfBytes.
+  ///
+  /// If this field is NULL, then the memory resource is not currently allocated.
+  pub image_handle: Handle,
+  /// The device handle for which the memory resource has been allocated.
+  ///
+  /// If ImageHandle is NULL, then the memory resource is not currently allocated.
+  ///
+  /// If this field is NULL, then the memory resource is not associated with a device that is described by a device handle.
+  pub device_handle: Handle,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+/// `EFI_GCD_IO_TYPE` in specification.
+pub enum GcdIoType {
+  /// An I/O region that is visible to the boot processor.
+  /// However, there are no system components that are currently decoding this I/O region.
+  #[default]
+  NonExistent = 0,
+  /// An I/O region that is visible to the boot processor.
+  /// This I/O region is currently being decoded by a system component,
+  ///  but the I/O region cannot be used to access I/O devices.
+  Reserved,
+  /// An I/O region that is visible to the boot processor.
+  /// This I/O region is currently being decoded by a system component
+  /// that is producing I/O ports that can be used to access I/O devices.
+  Io,
+  Maximum,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// `EFI_GCD_IO_SPACE_DESCRIPTOR` in specification.
+pub struct IoSpaceDescriptor {
+  /// Physical address of the first byte in the I/O region.
+  pub base_address: PhysicalAddress,
+  /// Number of bytes in the I/O region.
+  pub length: u64,
+  /// Type of the I/O region.
+  pub io_type: GcdIoType,
+  /// The image handle of the agent that allocated the I/O resource described by PhysicalStart and NumberOfBytes.
+  ///
+  /// If this field is NULL, then the I/O resource is not currently allocated.
+  pub image_handle: Handle,
+  /// The device handle for which the I/O resource has been allocated.
+  ///
+  /// If ImageHandle is NULL , then the I/O resource is not currently allocated.
+  ///
+  /// If this field is NULL, then the I/O resource is not associated with a device that is described by a device handle.
+  pub device_handle: Handle,
+}
+
+#[repr(C)]
+/// Contains a table header and pointers to all of the DXE-specific services.
+///
+/// See <https://uefi.org/specs/PI/1.8A/V2_UEFI_System_Table.html#dxe-services-table>.
+pub struct DxeServicesTable {
+  pub header: TableHeader,
+
+  //
+  // Global Coherency
+  //
+  pub add_memory_space: AddMemorySpace,
+  pub allocate_memory_space: AllocateMemorySpace,
+  pub free_memory_space: FreeMemorySpace,
+  pub remove_memory_space: RemoveMemorySpace,
+  pub get_memory_space_descriptor: GetMemorySpaceDescriptor,
+  pub set_memory_space_attributes: SetMemorySpaceAttributes,
+  pub get_memory_space_map: GetMemorySpaceMap,
+  pub add_io_space: AddIoSpace,
+  pub allocate_io_space: AllocateIoSpace,
+  pub free_io_space: FreeIoSpace,
+  pub remove_io_space: RemoveIoSpace,
+  pub get_io_space_descriptor: GetIoSpaceDescriptor,
+  pub get_io_space_map: GetIoSpaceMap,
+
+  //
+  // Dispatcher Services
+  //
+  pub dispatch: Dispatch,
+  pub schedule: Schedule,
+  pub trust: Trust,
+
+  //
+  // Service to process a single firmware volume found in
+  // a capsule
+  //
+  pub process_firmware_volume: ProcessFirmwareVolume,
+
+  //
+  // Extension to Global Coherency Domain Services
+  //
+  pub set_memory_space_capabilities: SetMemorySpaceCapabilities,
+}
+
+impl core::default::Default for MemorySpaceDescriptor {
+  fn default() -> Self {
+    Self {
+      base_address: Default::default(),
+      length: Default::default(),
+      capabilities: Default::default(),
+      attributes: Default::default(),
+      memory_type: Default::default(),
+      image_handle: 0 as Handle,
+      device_handle: 0 as Handle,
+    }
+  }
+}
+
+impl core::default::Default for IoSpaceDescriptor {
+  fn default() -> Self {
+    Self {
+      base_address: Default::default(),
+      length: Default::default(),
+      io_type: Default::default(),
+      image_handle: 0 as Handle,
+      device_handle: 0 as Handle,
+    }
+  }
+}

--- a/src/dxe_services.rs
+++ b/src/dxe_services.rs
@@ -14,7 +14,7 @@
 //! SPDX-License-Identifier: BSD-2-Clause-Patent
 //!
 
-use core::ffi::c_void;
+use core::{default::Default, ffi::c_void};
 
 use r_efi::{
   efi::{Guid, Handle, PhysicalAddress, Status},
@@ -290,7 +290,7 @@ pub struct DxeServicesTable {
   pub set_memory_space_capabilities: SetMemorySpaceCapabilities,
 }
 
-impl core::default::Default for MemorySpaceDescriptor {
+impl Default for MemorySpaceDescriptor {
   fn default() -> Self {
     Self {
       base_address: Default::default(),
@@ -304,7 +304,7 @@ impl core::default::Default for MemorySpaceDescriptor {
   }
 }
 
-impl core::default::Default for IoSpaceDescriptor {
+impl Default for IoSpaceDescriptor {
   fn default() -> Self {
     Self {
       base_address: Default::default(),

--- a/src/dxe_services.rs
+++ b/src/dxe_services.rs
@@ -36,7 +36,7 @@ pub type AddMemorySpace = extern "efiapi" fn(GcdMemoryType, PhysicalAddress, u64
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.2
 pub type AllocateMemorySpace =
-  extern "efiapi" fn(GcdAllocateType, GcdMemoryType, u32, u64, *mut PhysicalAddress, Handle, Handle) -> Status;
+  extern "efiapi" fn(GcdAllocateType, GcdMemoryType, usize, u64, *mut PhysicalAddress, Handle, Handle) -> Status;
 
 /// This service frees nonexistent memory, reserved memory, system memory,
 /// or memory-mapped I/O resources from the global coherency domain of the processor.
@@ -87,7 +87,7 @@ pub type AddIoSpace = extern "efiapi" fn(GcdIoType, PhysicalAddress, u64) -> Sta
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.2.4.10
 pub type AllocateIoSpace =
-  extern "efiapi" fn(GcdAllocateType, GcdIoType, u32, u64, *mut PhysicalAddress, Handle, Handle) -> Status;
+  extern "efiapi" fn(GcdAllocateType, GcdIoType, usize, u64, *mut PhysicalAddress, Handle, Handle) -> Status;
 
 /// This service frees nonexistent I/O, reserved I/O, or I/O resources from the global coherency domain of the processor.
 ///
@@ -137,7 +137,7 @@ pub type Trust = extern "efiapi" fn(Handle, *const Guid) -> Status;
 ///
 /// # Documentation
 /// UEFI Platform Initialization Specification, Release 1.8, Section II-7.3. II-59 (This one does not have a section)
-pub type ProcessFirmwareVolume = extern "efiapi" fn(*const c_void, u32, *mut Handle) -> Status;
+pub type ProcessFirmwareVolume = extern "efiapi" fn(*const c_void, usize, *mut Handle) -> Status;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/src/fw_fs.rs
+++ b/src/fw_fs.rs
@@ -1,0 +1,37 @@
+//! Firmware Filesystem
+//!
+//! Exports services used to interact with the Firmware Filesystem (FFS).
+//!
+//! See <https://uefi.org/specs/PI/1.8A/V3_Design_Discussion.html#firmware-storage-introduction>.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+pub mod ffs;
+pub mod fv;
+pub mod fvb;
+
+pub use ffs::{
+  attributes::{raw as FfsRawAttribute, Attribute as FfsAttribute},
+  file::{
+    raw::{r#type as FfsFileRawType, state as FfsFileRawState},
+    State as FfsFileState, Type as FfsFileType,
+  },
+  section::{
+    header as FfsSectionHeader, raw_type as FfsSectionRawType, raw_type::encapsulated as FfsEncapsulatedSectionRawType,
+    EfiSectionType, Generic as FfsSectionGeneric, Type as FfsSectionType,
+  },
+  File as FfsFile, Section as FfsSection,
+};
+
+pub use fv::{
+  attributes::{raw::fv2 as Fv2RawAttributes, EfiFvAttributes, Fv2 as Fv2Attributes},
+  file::{raw::attribute as FvFileRawAttribute, Attribute as FvFileAttribute, EfiFvFileAttributes},
+  EfiFvFileType, FirmwareVolume, Header as FvHeader, WritePolicy,
+};
+
+pub use fvb::attributes::{raw::fvb2 as Fvb2RawAttributes, EfiFvbAttributes2, Fvb2 as Fvb2Attributes};

--- a/src/fw_fs/ffs.rs
+++ b/src/fw_fs/ffs.rs
@@ -1,0 +1,368 @@
+//! Firmware File System (FFS) Definitions and Support Code
+//!
+//! Based on the values defined in the UEFI Platform Initialization (PI) Specification V1.8A Section 3.2.2
+//! Firmware File System.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+pub mod attributes;
+pub mod file;
+pub mod section;
+
+use core::{
+  fmt,
+  mem::{size_of, size_of_val},
+  slice,
+};
+
+use r_efi::efi;
+use uuid::Uuid;
+
+use crate::address_helper::align_up;
+use crate::fw_fs::{
+  ffs::{
+    attributes::raw as FfsRawAttribute,
+    file::{raw::r#type as FfsFileRawType, Header as FfsFileHeader, Type as FfsFileType},
+    section as FfsSection,
+    section::{header as FfsSectionHeader, raw_type as FfsSectionRawType},
+  },
+  fv::{
+    file::{raw::attribute as FvRawAttribute, EfiFvFileAttributes},
+    FirmwareVolume, Header as FvHeader,
+  },
+  fvb::attributes::raw::fvb2 as Fvb2RawAttributes,
+};
+
+#[derive(Copy, Clone)]
+/// Firmware File System (FFS) File
+pub struct File {
+  containing_fv: FirmwareVolume,
+  ffs_file: *const FfsFileHeader,
+}
+
+impl File {
+  pub fn new(containing_fv: FirmwareVolume, base_address: u64) -> File {
+    let ffs_file: *const FfsFileHeader = base_address as *const FfsFileHeader;
+    File { containing_fv, ffs_file }
+  }
+
+  pub fn file_size(&self) -> u64 {
+    let mut size: u64 = 0;
+    unsafe {
+      size += (*self.ffs_file).size[0] as u64;
+      size += ((*self.ffs_file).size[1] as u64) << 8;
+      size += ((*self.ffs_file).size[2] as u64) << 16;
+    }
+    size
+  }
+
+  pub fn file_data_size(&self) -> usize {
+    let file_size = self.file_size() as usize;
+    if size_of::<FfsFileHeader>() > file_size {
+      0
+    } else {
+      file_size - size_of::<FfsFileHeader>()
+    }
+  }
+
+  pub fn file_type_raw(&self) -> u8 {
+    unsafe { (*self.ffs_file).file_type }
+  }
+
+  pub fn file_type(&self) -> Option<FfsFileType> {
+    match self.file_type_raw() {
+      FfsFileRawType::RAW => Some(FfsFileType::Raw),
+      FfsFileRawType::FREEFORM => Some(FfsFileType::FreeForm),
+      FfsFileRawType::SECURITY_CORE => Some(FfsFileType::SecurityCore),
+      FfsFileRawType::PEI_CORE => Some(FfsFileType::PeiCore),
+      FfsFileRawType::DXE_CORE => Some(FfsFileType::DxeCore),
+      FfsFileRawType::PEIM => Some(FfsFileType::Peim),
+      FfsFileRawType::DRIVER => Some(FfsFileType::Driver),
+      FfsFileRawType::COMBINED_PEIM_DRIVER => Some(FfsFileType::CombinedPeimDriver),
+      FfsFileRawType::APPLICATION => Some(FfsFileType::Application),
+      FfsFileRawType::MM => Some(FfsFileType::Mm),
+      FfsFileRawType::FIRMWARE_VOLUME_IMAGE => Some(FfsFileType::FirmwareVolumeImage),
+      FfsFileRawType::COMBINED_MM_DXE => Some(FfsFileType::CombinedMmDxe),
+      FfsFileRawType::MM_CORE => Some(FfsFileType::MmCore),
+      FfsFileRawType::MM_STANDALONE => Some(FfsFileType::MmStandalone),
+      FfsFileRawType::MM_CORE_STANDALONE => Some(FfsFileType::MmCoreStandalone),
+      FfsFileRawType::OEM_MIN..=FfsFileRawType::OEM_MAX => Some(FfsFileType::OemMin),
+      FfsFileRawType::DEBUG_MIN..=FfsFileRawType::DEBUG_MAX => Some(FfsFileType::DebugMin),
+      FfsFileRawType::FFS_PAD => Some(FfsFileType::FfsPad),
+      FfsFileRawType::FFS_MIN..=FfsFileRawType::FFS_MAX => Some(FfsFileType::FfsUnknown),
+      _ => None,
+    }
+  }
+
+  pub fn file_attributes(&self) -> EfiFvFileAttributes {
+    let attributes = unsafe { (*self.ffs_file).attributes };
+    let data_alignment = (attributes & FfsRawAttribute::DATA_ALIGNMENT) >> 3;
+    // decode alignment per Table 3.3 in PI spec 1.8 Part III.
+    let mut file_attributes: u32 =
+      match (data_alignment, (attributes & FfsRawAttribute::DATA_ALIGNMENT_2) == FfsRawAttribute::DATA_ALIGNMENT_2) {
+        (0, false) => 0,
+        (1, false) => 4,
+        (2, false) => 7,
+        (3, false) => 9,
+        (4, false) => 10,
+        (5, false) => 12,
+        (6, false) => 15,
+        (7, false) => 16,
+        (x, true) if (0..8).contains(&x) => (17 + x) as u32,
+        (_, _) => panic!("Invalid data_alignment!"),
+      };
+    if attributes & FfsRawAttribute::FIXED != 0 {
+      file_attributes |= FvRawAttribute::FIXED;
+    }
+    file_attributes as EfiFvFileAttributes
+  }
+
+  pub fn file_name(&self) -> efi::Guid {
+    unsafe { (*self.ffs_file).name }
+  }
+
+  pub fn base_address(&self) -> u64 {
+    self.ffs_file as u64
+  }
+
+  pub fn top_address(&self) -> u64 {
+    self.base_address() + self.file_size()
+  }
+
+  pub fn file_data(&self) -> &[u8] {
+    let data_ptr = self.base_address() as usize + size_of::<FfsFileHeader>();
+    let data_ptr = data_ptr as *mut u8;
+    unsafe { slice::from_raw_parts(data_ptr, self.file_data_size()) }
+  }
+
+  pub fn next_ffs_file(&self) -> Option<File> {
+    let mut next_file_address = self.ffs_file as u64;
+    next_file_address += self.file_size();
+
+    // per the PI spec, "Given a file F, the next file FvHeader is located at the next 8-byte aligned firmware volume
+    // offset following the last byte the file F"
+    // but, in fact, that just means "8-byte aligned" per the EDK2 implementation.
+    next_file_address = align_up(next_file_address, 0x8);
+
+    // check to see if we ran off the end of the FV yet.
+    let erase_byte: [u8; 1] =
+      if self.containing_fv.attributes() & Fvb2RawAttributes::ERASE_POLARITY != 0 { [0xFF] } else { [0] };
+    let remaining_space = self.containing_fv.top_address() - size_of::<FvHeader>() as u64;
+    if next_file_address <= remaining_space {
+      let test_size = size_of::<FvHeader>().min(remaining_space.try_into().unwrap());
+      let remaining_space_slice = unsafe { slice::from_raw_parts(next_file_address as *const u8, test_size) };
+
+      if remaining_space_slice.windows(size_of_val(&erase_byte)).all(|window| window == erase_byte) {
+        // No files are left, only erased bytes
+        return None;
+      }
+
+      let file = File::new(self.containing_fv, next_file_address);
+      // To be super paranoid, we could check a lot of things here to make sure we have a
+      // legit file and didn't run into empty space at the end of the FV. For now, assume
+      // if the "file_type" is something legit, that the file is good.
+
+      if file.file_type().is_some() {
+        return Some(file);
+      }
+    }
+    None
+  }
+
+  pub fn first_ffs_section(&self) -> Option<Section> {
+    if self.file_size() <= size_of::<FfsFileHeader>() as u64 {
+      return None;
+    }
+    Some(Section::new(*self, self.base_address() + size_of::<FfsFileHeader>() as u64))
+  }
+
+  pub fn ffs_sections(&self) -> impl Iterator<Item = Section> {
+    FfsSectionIterator::new(self.first_ffs_section())
+  }
+}
+
+impl fmt::Debug for File {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(
+      f,
+      "File @{:#x} type: {:?} name: {:?} size: {:?}",
+      self.base_address(),
+      self.file_type(),
+      Uuid::from_bytes_le(*self.file_name().as_bytes()),
+      self.file_size()
+    )
+  }
+}
+
+pub(crate) struct FileIterator {
+  next_ffs: Option<File>,
+}
+
+impl FileIterator {
+  pub fn new(start_file: File) -> FileIterator {
+    FileIterator { next_ffs: Some(start_file) }
+  }
+}
+
+impl Iterator for FileIterator {
+  type Item = File;
+  fn next(&mut self) -> Option<File> {
+    let current = self.next_ffs?;
+    self.next_ffs = current.next_ffs_file();
+    Some(current)
+  }
+}
+
+#[derive(Copy, Clone)]
+pub struct Section {
+  containing_ffs: File,
+  common_header: *const FfsSectionHeader::Common,
+  ffs_section: FfsSection::Generic,
+}
+
+impl Section {
+  pub fn new(containing_ffs: File, base_address: u64) -> Section {
+    let common_header: *const FfsSectionHeader::Common = base_address as *const FfsSectionHeader::Common;
+    Section {
+      containing_ffs,
+      common_header,
+      ffs_section: match unsafe { (*common_header).section_type } {
+        FfsSectionRawType::encapsulated::COMPRESSION => {
+          FfsSection::Generic::Compression(common_header as *const FfsSectionHeader::Compression)
+        }
+        FfsSectionRawType::encapsulated::GUID_DEFINED => {
+          FfsSection::Generic::GuidDefined(common_header as *const FfsSectionHeader::GuidDefined)
+        }
+        FfsSectionRawType::encapsulated::DISPOSABLE => {
+          FfsSection::Generic::Disposable(common_header as *const FfsSectionHeader::Disposable)
+        }
+        FfsSectionRawType::PE32 => FfsSection::Generic::Pe32(common_header as *const FfsSectionHeader::Pe32),
+        FfsSectionRawType::PIC => FfsSection::Generic::Pic(common_header as *const FfsSectionHeader::Pic),
+        FfsSectionRawType::TE => FfsSection::Generic::Te(common_header as *const FfsSectionHeader::Te),
+        FfsSectionRawType::DXE_DEPEX => {
+          FfsSection::Generic::DxeDepex(common_header as *const FfsSectionHeader::DxeDepex)
+        }
+        FfsSectionRawType::VERSION => FfsSection::Generic::Version(common_header as *const FfsSectionHeader::Version),
+        FfsSectionRawType::USER_INTERFACE => {
+          FfsSection::Generic::UserInterface(common_header as *const FfsSectionHeader::UserInterface)
+        }
+        FfsSectionRawType::COMPATIBILITY16 => {
+          FfsSection::Generic::Compatibility16(common_header as *const FfsSectionHeader::Compatibility16)
+        }
+        FfsSectionRawType::FIRMWARE_VOLUME_IMAGE => {
+          FfsSection::Generic::FirmwareVolumeImage(common_header as *const FfsSectionHeader::FirmwareVolumeImage)
+        }
+        FfsSectionRawType::FREEFORM_SUBTYPE_GUID => {
+          FfsSection::Generic::FreeformSubtypeGuid(common_header as *const FfsSectionHeader::FreeformSubtypeGuid)
+        }
+        FfsSectionRawType::RAW => FfsSection::Generic::Raw(common_header as *const FfsSectionHeader::Raw),
+        FfsSectionRawType::PEI_DEPEX => {
+          FfsSection::Generic::PeiDepex(common_header as *const FfsSectionHeader::PeiDepex)
+        }
+        FfsSectionRawType::MM_DEPEX => FfsSection::Generic::MmDepex(common_header as *const FfsSectionHeader::MmDepex),
+        _ => FfsSection::Generic::Unknown(common_header),
+      },
+    }
+  }
+
+  pub fn is_pe32(&self) -> bool {
+    if let FfsSection::Generic::Pe32(_) = &self.ffs_section {
+      return true;
+    }
+    false
+  }
+
+  pub fn base_address(&self) -> u64 {
+    self.common_header as u64
+  }
+
+  pub fn section_type(&self) -> Option<FfsSection::Type> {
+    match self.ffs_section {
+      FfsSection::Generic::Compression(_) => Some(FfsSection::Type::Compression),
+      FfsSection::Generic::GuidDefined(_) => Some(FfsSection::Type::GuidDefined),
+      FfsSection::Generic::Disposable(_) => Some(FfsSection::Type::Disposable),
+      FfsSection::Generic::Pe32(_) => Some(FfsSection::Type::Pe32),
+      FfsSection::Generic::Pic(_) => Some(FfsSection::Type::Pic),
+      FfsSection::Generic::Te(_) => Some(FfsSection::Type::Te),
+      FfsSection::Generic::DxeDepex(_) => Some(FfsSection::Type::DxeDepex),
+      FfsSection::Generic::Version(_) => Some(FfsSection::Type::Version),
+      FfsSection::Generic::UserInterface(_) => Some(FfsSection::Type::UserInterface),
+      FfsSection::Generic::Compatibility16(_) => Some(FfsSection::Type::Compatibility16),
+      FfsSection::Generic::FirmwareVolumeImage(_) => Some(FfsSection::Type::FirmwareVolumeImage),
+      FfsSection::Generic::FreeformSubtypeGuid(_) => Some(FfsSection::Type::FreeformSubtypeGuid),
+      FfsSection::Generic::Raw(_) => Some(FfsSection::Type::Raw),
+      FfsSection::Generic::PeiDepex(_) => Some(FfsSection::Type::PeiDepex),
+      FfsSection::Generic::MmDepex(_) => Some(FfsSection::Type::MmDepex),
+      _ => None,
+    }
+  }
+
+  pub fn section_size(&self) -> u64 {
+    let mut size: u64 = 0;
+    unsafe {
+      size += (*self.common_header).size[0] as u64;
+      size += ((*self.common_header).size[1] as u64) << 8;
+      size += ((*self.common_header).size[2] as u64) << 16;
+    }
+    size
+  }
+
+  pub fn section_data(&self) -> &[u8] {
+    let data_offset = match self.ffs_section {
+      FfsSection::Generic::Compression(_) => size_of::<FfsSectionHeader::Compression>() as u64,
+      FfsSection::Generic::FreeformSubtypeGuid(_) => size_of::<FfsSectionHeader::FreeformSubtypeGuid>() as u64,
+      FfsSection::Generic::GuidDefined(guid_defined) => unsafe { (*guid_defined).data_offset as u64 },
+      _ => size_of::<FfsSectionHeader::Common>() as u64,
+    };
+
+    let data_start_addr = self.base_address() + data_offset;
+    let data_size = self.section_size() - data_offset;
+
+    unsafe { slice::from_raw_parts(data_start_addr as *const u8, data_size as usize) }
+  }
+
+  pub fn next_section(&self) -> Option<Section> {
+    let mut next_section_address = self.common_header as u64;
+    next_section_address += self.section_size();
+
+    // per the PI spec, "The section headers aligned on 4 byte boundaries relative to the start of the file's image"
+    // but, in fact, that just means "4-byte aligned" per the EDK2 implementation.
+    next_section_address = align_up(next_section_address, 0x4);
+
+    // check to see if we ran off the end of the file yet.
+    if next_section_address <= (self.containing_ffs.top_address() - size_of::<FfsSectionHeader::Common>() as u64) {
+      return Some(Section::new(self.containing_ffs, next_section_address));
+    }
+    None
+  }
+}
+
+impl fmt::Debug for Section {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "Section @{:#x} type: {:?} size: {:?}", self.base_address(), self.section_type(), self.section_size())
+  }
+}
+
+struct FfsSectionIterator {
+  next_section: Option<Section>,
+}
+
+impl FfsSectionIterator {
+  pub fn new(start_section: Option<Section>) -> FfsSectionIterator {
+    FfsSectionIterator { next_section: start_section }
+  }
+}
+
+impl Iterator for FfsSectionIterator {
+  type Item = Section;
+  fn next(&mut self) -> Option<Section> {
+    let current = self.next_section?;
+    self.next_section = current.next_section();
+    Some(current)
+  }
+}

--- a/src/fw_fs/ffs.rs
+++ b/src/fw_fs/ffs.rs
@@ -271,10 +271,7 @@ impl Section {
   }
 
   pub fn is_pe32(&self) -> bool {
-    if let FfsSection::Generic::Pe32(_) = &self.ffs_section {
-      return true;
-    }
-    false
+    matches!(&self.ffs_section, FfsSection::Generic::Pe32(_))
   }
 
   pub fn base_address(&self) -> u64 {

--- a/src/fw_fs/ffs/attributes.rs
+++ b/src/fw_fs/ffs/attributes.rs
@@ -1,0 +1,29 @@
+//! Firmware File System (FFS) File Attribute Definitions
+//!
+//! Based on the values defined in the UEFI Platform Initialization (PI) Specification V1.8A Section 3.2.3.1
+//! EFI_FFS_FILE_HEADER.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+pub mod raw {
+  pub const LARGE_FILE: u8 = 0x01;
+  pub const DATA_ALIGNMENT_2: u8 = 0x02;
+  pub const FIXED: u8 = 0x04;
+  pub const DATA_ALIGNMENT: u8 = 0x38;
+  pub const CHECKSUM: u8 = 0x40;
+}
+
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum Attribute {
+  LargeFile = raw::LARGE_FILE,
+  DataAlignment2 = raw::DATA_ALIGNMENT_2,
+  Fixed = raw::FIXED,
+  DataAlignment = raw::DATA_ALIGNMENT,
+  Checksum = raw::CHECKSUM,
+}

--- a/src/fw_fs/ffs/file.rs
+++ b/src/fw_fs/ffs/file.rs
@@ -1,0 +1,103 @@
+//! Firmware File System (FFS) File Definitions
+//!
+//! Based on the values defined in the UEFI Platform Initialization (PI) Specification V1.8A Section 3.2.3.1
+//! EFI_FFS_FILE_HEADER.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+use r_efi::efi;
+
+pub mod raw {
+  /// File State Bits
+  pub mod state {
+    pub const HEADER_CONSTRUCTION: u8 = 0x01;
+    pub const HEADER_VALID: u8 = 0x02;
+    pub const DATA_VALID: u8 = 0x04;
+    pub const MARKED_FOR_UPDATE: u8 = 0x08;
+    pub const DELETED: u8 = 0x10;
+    pub const HEADER_INVALID: u8 = 0x20;
+  }
+
+  /// File Type Definitions
+  pub mod r#type {
+    pub const ALL: u8 = 0x00;
+    pub const RAW: u8 = 0x01;
+    pub const FREEFORM: u8 = 0x02;
+    pub const SECURITY_CORE: u8 = 0x03;
+    pub const PEI_CORE: u8 = 0x04;
+    pub const DXE_CORE: u8 = 0x05;
+    pub const PEIM: u8 = 0x06;
+    pub const DRIVER: u8 = 0x07;
+    pub const COMBINED_PEIM_DRIVER: u8 = 0x08;
+    pub const APPLICATION: u8 = 0x09;
+    pub const MM: u8 = 0x0A;
+    pub const FIRMWARE_VOLUME_IMAGE: u8 = 0x0B;
+    pub const COMBINED_MM_DXE: u8 = 0x0C;
+    pub const MM_CORE: u8 = 0x0D;
+    pub const MM_STANDALONE: u8 = 0x0E;
+    pub const MM_CORE_STANDALONE: u8 = 0x0F;
+    pub const OEM_MIN: u8 = 0xc0;
+    pub const OEM_MAX: u8 = 0xdf;
+    pub const DEBUG_MIN: u8 = 0xe0;
+    pub const DEBUG_MAX: u8 = 0xef;
+    pub const FFS_MIN: u8 = 0xf1;
+    pub const FFS_MAX: u8 = 0xff;
+    pub const FFS_PAD: u8 = 0xf0;
+  }
+}
+
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum Type {
+  All = raw::r#type::ALL,
+  Raw = raw::r#type::RAW,
+  FreeForm = raw::r#type::FREEFORM,
+  SecurityCore = raw::r#type::SECURITY_CORE,
+  PeiCore = raw::r#type::PEI_CORE,
+  DxeCore = raw::r#type::DXE_CORE,
+  Peim = raw::r#type::PEIM,
+  Driver = raw::r#type::DRIVER,
+  CombinedPeimDriver = raw::r#type::COMBINED_PEIM_DRIVER,
+  Application = raw::r#type::APPLICATION,
+  Mm = raw::r#type::MM,
+  FirmwareVolumeImage = raw::r#type::FIRMWARE_VOLUME_IMAGE,
+  CombinedMmDxe = raw::r#type::COMBINED_MM_DXE,
+  MmCore = raw::r#type::MM_CORE,
+  MmStandalone = raw::r#type::MM_STANDALONE,
+  MmCoreStandalone = raw::r#type::MM_CORE_STANDALONE,
+  OemMin = raw::r#type::OEM_MIN,
+  OemMax = raw::r#type::OEM_MAX,
+  DebugMin = raw::r#type::DEBUG_MIN,
+  DebugMax = raw::r#type::DEBUG_MAX,
+  FfsPad = raw::r#type::FFS_PAD,
+  FfsUnknown = raw::r#type::FFS_MIN,
+  FfsMax = raw::r#type::FFS_MAX,
+}
+
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum State {
+  HeaderConstruction = raw::state::HEADER_CONSTRUCTION,
+  HeaderValid = raw::state::HEADER_VALID,
+  DataValid = raw::state::DATA_VALID,
+  MarkedForUpdate = raw::state::MARKED_FOR_UPDATE,
+  Deleted = raw::state::DELETED,
+  HeaderInvalid = raw::state::HEADER_INVALID,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub(crate) struct Header {
+  pub(crate) name: efi::Guid,
+  pub(crate) integrity_check_header: u8,
+  pub(crate) integrity_check_file: u8,
+  pub(crate) file_type: u8,
+  pub(crate) attributes: u8,
+  pub(crate) size: [u8; 3],
+  pub(crate) state: u8,
+}

--- a/src/fw_fs/ffs/section.rs
+++ b/src/fw_fs/ffs/section.rs
@@ -1,0 +1,206 @@
+//! Firmware File System (FFS) Section Definition
+//!
+//! Based on the values defined in the UEFI Platform Initialization (PI) Specification V1.8A Section 3.2.4
+//! Firmware File Section.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+pub type EfiSectionType = u8;
+
+/// Firmware File System Leaf Section Types
+/// Note: Typically called `EFI_SECTION_*` in EDK II code.
+pub mod raw_type {
+  /// Pseudo type. It is used as a wild card when retrieving sections to match all types.
+  pub const ALL: u8 = 0x00;
+
+  pub mod encapsulated {
+    pub const COMPRESSION: u8 = 0x01;
+    pub const GUID_DEFINED: u8 = 0x02;
+    pub const DISPOSABLE: u8 = 0x03;
+  }
+
+  pub const PE32: u8 = 0x10;
+  pub const PIC: u8 = 0x11;
+  pub const TE: u8 = 0x12;
+  pub const DXE_DEPEX: u8 = 0x13;
+  pub const VERSION: u8 = 0x14;
+  pub const USER_INTERFACE: u8 = 0x15;
+  pub const COMPATIBILITY16: u8 = 0x16;
+  pub const FIRMWARE_VOLUME_IMAGE: u8 = 0x17;
+  pub const FREEFORM_SUBTYPE_GUID: u8 = 0x18;
+  pub const RAW: u8 = 0x19;
+  pub const PEI_DEPEX: u8 = 0x1B;
+  pub const MM_DEPEX: u8 = 0x1C;
+}
+
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(test, derive(serde::Deserialize))]
+pub enum Type {
+  All = raw_type::ALL,
+  Compression = raw_type::encapsulated::COMPRESSION,
+  GuidDefined = raw_type::encapsulated::GUID_DEFINED,
+  Disposable = raw_type::encapsulated::DISPOSABLE,
+  Pe32 = raw_type::PE32,
+  Pic = raw_type::PIC,
+  Te = raw_type::TE,
+  DxeDepex = raw_type::DXE_DEPEX,
+  Version = raw_type::VERSION,
+  UserInterface = raw_type::USER_INTERFACE,
+  Compatibility16 = raw_type::COMPATIBILITY16,
+  FirmwareVolumeImage = raw_type::FIRMWARE_VOLUME_IMAGE,
+  FreeformSubtypeGuid = raw_type::FREEFORM_SUBTYPE_GUID,
+  Raw = raw_type::RAW,
+  PeiDepex = raw_type::PEI_DEPEX,
+  MmDepex = raw_type::MM_DEPEX,
+}
+
+pub mod header {
+  use r_efi::base::Guid;
+
+  /// EFI_COMMON_SECTION_HEADER
+  #[repr(C)]
+  #[derive(Debug)]
+  pub struct Common {
+    pub size: [u8; 3],
+    pub section_type: u8,
+  }
+
+  /// EFI_COMPRESSION_SECTION
+  #[repr(C)]
+  #[derive(Debug)]
+  pub struct Compression {
+    pub common_header: Common,
+    pub uncompressed_length: u32,
+    pub compression_type: u8,
+  }
+
+  /// EFI_GUID_DEFINED_SECTION
+  #[repr(C)]
+  #[derive(Debug)]
+  pub struct GuidDefined {
+    pub common_header: Common,
+    pub section_definition_guid: Guid,
+    pub data_offset: u16,
+    pub attributes: u16,
+    // Guid-specific header fields.
+  }
+
+  /// EFI_DISPOSABLE_SECTION
+  #[repr(C)]
+  #[derive(Debug)]
+  pub struct Disposable {
+    pub common_header: Common,
+  }
+
+  /// EFI_PE32_SECTION
+  #[repr(C)]
+  #[derive(Debug)]
+  pub struct Pe32 {
+    pub common_header: Common,
+  }
+
+  /// EFI_PIC_SECTION
+  #[repr(C)]
+  #[derive(Debug)]
+  pub struct Pic {
+    pub common_header: Common,
+  }
+
+  /// EFI_TE_SECTION
+  #[repr(C)]
+  #[derive(Debug)]
+  pub struct Te {
+    pub common_header: Common,
+  }
+
+  /// EFI_DXE_DEPEX_SECTION
+  #[repr(C)]
+  #[derive(Debug)]
+  pub struct DxeDepex {
+    pub common_header: Common,
+  }
+
+  /// EFI_VERSION_SECTION
+  #[repr(C)]
+  #[derive(Debug)]
+  pub struct Version {
+    pub common_header: Common,
+    pub build_number: u16,
+  }
+
+  /// EFI_USER_INTERFACE_SECTION
+  #[repr(C)]
+  #[derive(Debug)]
+  pub struct UserInterface {
+    pub common_header: Common,
+  }
+
+  /// EFI_COMPATIBILITY16_SECTION
+  #[repr(C)]
+  #[derive(Debug)]
+  pub struct Compatibility16 {
+    pub common_header: Common,
+  }
+
+  /// EFI_FIRMWARE_VOLUME_IMAGE_SECTION
+  #[repr(C)]
+  #[derive(Debug)]
+  pub struct FirmwareVolumeImage {
+    pub common_header: Common,
+  }
+
+  /// EFI_FREEFORM_SUBTYPE_GUID_SECTION
+  #[repr(C)]
+  #[derive(Debug)]
+  pub struct FreeformSubtypeGuid {
+    pub common_header: Common,
+    pub sub_type_guid: Guid,
+  }
+
+  /// EFI_RAW_SECTION
+  #[repr(C)]
+  #[derive(Debug)]
+  pub struct Raw {
+    pub common_header: Common,
+  }
+
+  /// EFI_PEI_DEPEX_SECTION
+  #[repr(C)]
+  #[derive(Debug)]
+  pub struct PeiDepex {
+    pub common_header: Common,
+  }
+
+  /// EFI_MM_DEPEX_SECTION
+  #[repr(C)]
+  #[derive(Debug)]
+  pub struct MmDepex {
+    pub common_header: Common,
+  }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum Generic {
+  Compression(*const header::Compression),
+  GuidDefined(*const header::GuidDefined),
+  Disposable(*const header::Disposable),
+  Pe32(*const header::Pe32),
+  Pic(*const header::Pic),
+  Te(*const header::Te),
+  DxeDepex(*const header::DxeDepex),
+  Version(*const header::Version),
+  UserInterface(*const header::UserInterface),
+  Compatibility16(*const header::Compatibility16),
+  FirmwareVolumeImage(*const header::FirmwareVolumeImage),
+  FreeformSubtypeGuid(*const header::FreeformSubtypeGuid),
+  Raw(*const header::Raw),
+  PeiDepex(*const header::PeiDepex),
+  MmDepex(*const header::MmDepex),
+  Unknown(*const header::Common),
+}

--- a/src/fw_fs/fv.rs
+++ b/src/fw_fs/fv.rs
@@ -1,0 +1,326 @@
+//! Firmware Volume (FV) Definitions and Support Code
+//!
+//! Based on the values defined in the UEFI Platform Initialization (PI) Specification V1.8A 3.1 Firmware Storage
+//! Code Definitions.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+pub mod attributes;
+pub mod file;
+
+extern crate alloc;
+
+use crate::address_helper::align_up;
+use alloc::string::ToString;
+use core::{fmt, slice};
+use r_efi::efi::Guid;
+use uuid::Uuid;
+
+use crate::fw_fs::{
+  ffs::{File as FfsFile, FileIterator as FfsFileIterator},
+  fvb::attributes::EfiFvbAttributes2,
+};
+
+pub type EfiFvFileType = u8;
+
+/// Firmware Volume Write Policy bit definitions
+/// Note: Typically named `EFI_FV_*` in EDK II code.
+mod raw {
+  pub(super) mod write_policy {
+    pub const UNRELIABLE_WRITE: u32 = 0x00000000;
+    pub const RELIABLE_WRITE: u32 = 0x00000001;
+  }
+}
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum WritePolicy {
+  UnreliableWrite = raw::write_policy::UNRELIABLE_WRITE,
+  ReliableWrite = raw::write_policy::RELIABLE_WRITE,
+}
+
+/// EFI_FIRMWARE_VOLUME_HEADER
+#[repr(C)]
+#[derive(Debug)]
+pub struct Header {
+  pub(crate) zero_vector: [u8; 16],
+  pub(crate) file_system_guid: Guid,
+  pub(crate) fv_length: u64,
+  pub(crate) signature: u32,
+  pub(crate) attributes: EfiFvbAttributes2,
+  pub(crate) header_length: u16,
+  pub(crate) checksum: u16,
+  pub(crate) ext_header_offset: u16,
+  pub(crate) reserved: u8,
+  pub(crate) revision: u8,
+  // Block map starts here
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub(crate) struct BlockMapEntry {
+  pub(crate) num_blocks: u32,
+  pub(crate) length: u32,
+}
+
+/// EFI_FIRMWARE_VOLUME_EXT_HEADER
+#[repr(C)]
+#[derive(Debug)]
+pub(crate) struct ExtHeader {
+  pub(crate) fv_name: Guid,
+  pub(crate) ext_header_size: u32,
+}
+
+#[derive(Copy, Clone)]
+pub struct FirmwareVolume {
+  fv_header: *const self::Header,
+}
+
+impl FirmwareVolume {
+  pub fn new(base_address: u64) -> FirmwareVolume {
+    let fv_header = base_address as *const self::Header;
+    // Note: This assumes that base_address points to something that is an FV with an FFS on it.
+    // More robust code would evaluate the FV header file_system_guid and make sure it actually has the correct
+    // filesystem type, and probably a number of other sanity checks.
+    FirmwareVolume { fv_header }
+  }
+
+  fn ext_header(&self) -> Option<*const ExtHeader> {
+    let ext_header_offset = unsafe { (*self.fv_header).ext_header_offset as u64 };
+    if ext_header_offset == 0 {
+      return None;
+    }
+    Some((self.base_address() + ext_header_offset) as *const ExtHeader)
+  }
+
+  fn block_map(&self) -> &[BlockMapEntry] {
+    let block_map_start = unsafe { self.fv_header.offset(1) as *const BlockMapEntry };
+    let mut count = 0;
+    let mut current_block_map_ptr = block_map_start;
+
+    unsafe {
+      while (*current_block_map_ptr).num_blocks != 0 && (*current_block_map_ptr).length != 0 {
+        count += 1;
+        current_block_map_ptr = current_block_map_ptr.add(1);
+      }
+      slice::from_raw_parts(block_map_start, count)
+    }
+  }
+
+  pub fn fv_name(&self) -> Option<Guid> {
+    if let Some(ext_header) = self.ext_header() {
+      return unsafe { Some((*ext_header).fv_name) };
+    }
+    None
+  }
+
+  pub fn first_ffs_file(&self) -> FfsFile {
+    let mut ffs_address = self.fv_header as u64;
+    if let Some(ext_header) = self.ext_header() {
+      // if ext header exists, then file starts after ext header
+      unsafe {
+        ffs_address += (*self.fv_header).ext_header_offset as u64;
+        ffs_address += (*ext_header).ext_header_size as u64;
+      }
+    } else {
+      // otherwise the file starts after the main header.
+      unsafe { ffs_address += (*self.fv_header).header_length as u64 }
+    }
+    ffs_address = align_up(ffs_address, 0x8);
+    // Note: it appears possible from the EDK2 implementation that an FV could have a file system with no actual
+    // files.
+    // More robust code would check and handle that case.
+    FfsFile::new(*self, ffs_address)
+  }
+
+  pub fn ffs_files(&self) -> impl Iterator<Item = FfsFile> {
+    FfsFileIterator::new(self.first_ffs_file())
+  }
+
+  pub fn base_address(&self) -> u64 {
+    self.fv_header as u64
+  }
+
+  pub fn top_address(&self) -> u64 {
+    unsafe { self.base_address() + (*self.fv_header).fv_length }
+  }
+
+  pub fn attributes(&self) -> EfiFvbAttributes2 {
+    unsafe { (*self.fv_header).attributes }
+  }
+
+  pub fn get_lba_info(&self, lba: u32) -> Result<(u32, u32, u32), ()> {
+    let block_map = self.block_map();
+
+    let mut total_blocks = 0;
+    let mut offset = 0;
+    let mut block_size = 0;
+
+    for entry in block_map {
+      total_blocks += entry.num_blocks;
+      block_size = entry.length;
+      if lba < total_blocks {
+        break;
+      }
+      offset += entry.num_blocks * entry.length;
+    }
+
+    if lba >= total_blocks {
+      return Err(()); //lba out of range.
+    }
+
+    let remaining_blocks = total_blocks - lba;
+    Ok((offset + lba * block_size, block_size, remaining_blocks))
+  }
+}
+
+impl fmt::Debug for FirmwareVolume {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(
+      f,
+      "FirmwareVolume@{:#x}-{:#x} name: {:}",
+      self.base_address(),
+      self.top_address(),
+      match self.fv_name() {
+        Some(guid) => Uuid::from_bytes_le(*guid.as_bytes()).to_string(),
+        None => "Unspecified".to_string(),
+      }
+    )
+  }
+}
+
+#[cfg(test)]
+mod unit_tests {
+  use std::{
+    collections::HashMap,
+    env,
+    error::Error,
+    fs::{self, File},
+    path::Path,
+  };
+
+  use core::slice;
+  use serde::Deserialize;
+  use uuid::Uuid;
+
+  use crate::fw_fs::{
+    ffs::{file::raw::r#type as FfsRawFileType, section::Type as FfsSectionType, Section as FfsSection},
+    fv::FirmwareVolume,
+  };
+
+  #[derive(Debug, Deserialize)]
+  struct TargetValues {
+    total_number_of_files: u32,
+    files_to_test: HashMap<String, FfsFileTargetValues>,
+  }
+
+  #[derive(Debug, Deserialize)]
+  struct FfsFileTargetValues {
+    base_address: u64,
+    file_type: u8,
+    attributes: u32,
+    size: u64,
+    data_size: usize,
+    number_of_sections: usize,
+    sections: HashMap<usize, FfsSectionTargetValues>,
+  }
+
+  #[derive(Debug, Deserialize)]
+  struct FfsSectionTargetValues {
+    base_address: u64,
+    section_type: Option<FfsSectionType>,
+    size: u64,
+    text: Option<String>,
+  }
+
+  #[test]
+  fn trivial_unit_test() {
+    assert_eq!(FfsRawFileType::ALL, 0x00);
+  }
+
+  #[test]
+  fn test_firmware_volume() -> Result<(), Box<dyn Error>> {
+    let root = Path::new(&env::var("CARGO_MANIFEST_DIR")?).join("test_resources");
+
+    let fv_bytes = fs::read(root.join("DXEFV.Fv"))?;
+    let fv = FirmwareVolume::new(fv_bytes.as_ptr() as u64);
+
+    let mut expected_values =
+      serde_yaml::from_reader::<File, TargetValues>(File::open(root.join("DXEFV_expected_values.yml"))?)?;
+
+    let mut count = 0;
+    for ffs_file in fv.ffs_files() {
+      count += 1;
+      let file_name = Uuid::from_bytes_le(*ffs_file.file_name().as_bytes()).to_string().to_uppercase();
+      let sections = ffs_file.ffs_sections().collect::<Vec<_>>();
+      if let Some(mut target) = expected_values.files_to_test.remove(&file_name) {
+        assert_eq!(
+          target.base_address,
+          ffs_file.base_address() - fv_bytes.as_ptr() as u64,
+          "[{file_name}] Error with the file Base Address"
+        );
+        assert_eq!(target.file_type, ffs_file.file_type_raw(), "[{file_name}] Error with the file type.");
+        assert_eq!(target.attributes, ffs_file.file_attributes(), "[{file_name}] Error with the file attributes.");
+        assert_eq!(
+          target.data_size,
+          ffs_file.file_data_size(),
+          "[{file_name}] Error with the file data size (Body size)."
+        );
+        assert_eq!(target.size, ffs_file.file_size(), "[{file_name}] Error with the file size (Full size).");
+        assert_eq!(
+          target.number_of_sections,
+          sections.len(),
+          "[{file_name}] Error with the number of section in the File"
+        );
+
+        for (idx, section) in sections.iter().enumerate() {
+          if let Some(target) = target.sections.remove(&idx) {
+            assert_eq!(
+              target.base_address,
+              section.base_address() - fv_bytes.as_ptr() as u64,
+              "[{file_name}, section: {idx}] Error with the section Base Address"
+            );
+            assert_eq!(
+              target.section_type,
+              section.section_type(),
+              "[{file_name}, section: {idx}] Error with the section Type"
+            );
+            assert_eq!(
+              target.size,
+              section.section_size(),
+              "[{file_name}, section: {idx}] Error with the section Size"
+            );
+            assert_eq!(
+              target.text,
+              extract_text_from_section(section),
+              "[{file_name}, section: {idx}] Error with the section Text"
+            );
+          }
+        }
+
+        assert!(target.sections.is_empty(), "Some section use case has not been run.");
+      }
+    }
+    assert_eq!(
+      expected_values.total_number_of_files, count,
+      "The number of file found does not match the expected one."
+    );
+    assert!(expected_values.files_to_test.is_empty(), "Some file use case has not been run.");
+    Ok(())
+  }
+
+  fn extract_text_from_section(section: &FfsSection) -> Option<String> {
+    if section.section_type() == Some(FfsSectionType::UserInterface) {
+      let data = section.section_data();
+      let display_name = unsafe { slice::from_raw_parts(data.as_ptr() as *const u16, (data.len() / 2) - 1) };
+      Some(String::from_utf16_lossy(display_name))
+    } else {
+      None
+    }
+  }
+}

--- a/src/fw_fs/fv/attributes.rs
+++ b/src/fw_fs/fv/attributes.rs
@@ -1,0 +1,116 @@
+//! Firmware Volume Attributes
+//!
+//! Based on the values defined in the UEFI Platform Initialization (PI) Specification V1.8A Section 3.2.1.1
+//! EFI_FIRMWARE_VOLUME_HEADER.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+pub type EfiFvAttributes = u64;
+
+/// EFI_FV_ATTRIBUTES bit definitions
+/// Note: `ALIGNMENT` traditionally has the same value as `ALIGNMENT_2G`. To reduce confusion, only
+///       `ALIGNMENT_2G` is specified.
+pub mod raw {
+  pub mod fv2 {
+    pub const READ_DISABLE_CAP: u64 = 0x0000000000000001;
+    pub const READ_ENABLE_CAP: u64 = 0x0000000000000002;
+    pub const READ_STATUS: u64 = 0x0000000000000004;
+    pub const WRITE_DISABLE_CAP: u64 = 0x0000000000000008;
+    pub const WRITE_ENABLE_CAP: u64 = 0x0000000000000010;
+    pub const WRITE_STATUS: u64 = 0x0000000000000020;
+    pub const LOCK_CAP: u64 = 0x0000000000000040;
+    pub const LOCK_STATUS: u64 = 0x0000000000000080;
+    pub const WRITE_POLICY_RELIABLE: u64 = 0x0000000000000100;
+    pub const READ_LOCK_CAP: u64 = 0x0000000000001000;
+    pub const READ_LOCK_STATUS: u64 = 0x0000000000002000;
+    pub const WRITE_LOCK_CAP: u64 = 0x0000000000004000;
+    pub const WRITE_LOCK_STATUS: u64 = 0x0000000000008000;
+    pub const ALIGNMENT_1: u64 = 0x0000000000000000;
+    pub const ALIGNMENT_2: u64 = 0x0000000000010000;
+    pub const ALIGNMENT_4: u64 = 0x0000000000020000;
+    pub const ALIGNMENT_8: u64 = 0x0000000000030000;
+    pub const ALIGNMENT_16: u64 = 0x0000000000040000;
+    pub const ALIGNMENT_32: u64 = 0x0000000000050000;
+    pub const ALIGNMENT_64: u64 = 0x0000000000060000;
+    pub const ALIGNMENT_128: u64 = 0x0000000000070000;
+    pub const ALIGNMENT_256: u64 = 0x0000000000080000;
+    pub const ALIGNMENT_512: u64 = 0x0000000000090000;
+    pub const ALIGNMENT_1K: u64 = 0x00000000000A0000;
+    pub const ALIGNMENT_2K: u64 = 0x00000000000B0000;
+    pub const ALIGNMENT_4K: u64 = 0x00000000000C0000;
+    pub const ALIGNMENT_8K: u64 = 0x00000000000D0000;
+    pub const ALIGNMENT_16K: u64 = 0x00000000000E0000;
+    pub const ALIGNMENT_32K: u64 = 0x00000000000F0000;
+    pub const ALIGNMENT_64K: u64 = 0x0000000000100000;
+    pub const ALIGNMENT_128K: u64 = 0x0000000000110000;
+    pub const ALIGNMENT_256K: u64 = 0x0000000000120000;
+    pub const ALIGNMENT_512K: u64 = 0x0000000000130000;
+    pub const ALIGNMENT_1M: u64 = 0x0000000000140000;
+    pub const ALIGNMENT_2M: u64 = 0x0000000000150000;
+    pub const ALIGNMENT_4M: u64 = 0x0000000000160000;
+    pub const ALIGNMENT_8M: u64 = 0x0000000000170000;
+    pub const ALIGNMENT_16M: u64 = 0x0000000000180000;
+    pub const ALIGNMENT_32M: u64 = 0x0000000000190000;
+    pub const ALIGNMENT_64M: u64 = 0x00000000001A0000;
+    pub const ALIGNMENT_128M: u64 = 0x00000000001B0000;
+    pub const ALIGNMENT_256M: u64 = 0x00000000001C0000;
+    pub const ALIGNMENT_512M: u64 = 0x00000000001D0000;
+    pub const ALIGNMENT_1G: u64 = 0x00000000001E0000;
+    pub const ALIGNMENT_2G: u64 = 0x00000000001F0000;
+  }
+}
+
+#[repr(u64)]
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum Fv2 {
+  ReadDisableCap = raw::fv2::READ_DISABLE_CAP,
+  ReadEnableCap = raw::fv2::READ_ENABLE_CAP,
+  ReadStatus = raw::fv2::READ_STATUS,
+  WriteDisableCap = raw::fv2::WRITE_DISABLE_CAP,
+  WriteEnableCap = raw::fv2::WRITE_ENABLE_CAP,
+  WriteStatus = raw::fv2::WRITE_STATUS,
+  LockCap = raw::fv2::LOCK_CAP,
+  LockStatus = raw::fv2::LOCK_STATUS,
+  WritePolicyReliable = raw::fv2::WRITE_POLICY_RELIABLE,
+  ReadLockCap = raw::fv2::READ_LOCK_CAP,
+  ReadLockStatus = raw::fv2::READ_LOCK_STATUS,
+  WriteLockCap = raw::fv2::WRITE_LOCK_CAP,
+  WriteLockStatus = raw::fv2::WRITE_LOCK_STATUS,
+  Alignment1 = raw::fv2::ALIGNMENT_1,
+  Alignment2 = raw::fv2::ALIGNMENT_2,
+  Alignment4 = raw::fv2::ALIGNMENT_4,
+  Alignment8 = raw::fv2::ALIGNMENT_8,
+  Alignment16 = raw::fv2::ALIGNMENT_16,
+  Alignment32 = raw::fv2::ALIGNMENT_32,
+  Alignment64 = raw::fv2::ALIGNMENT_64,
+  Alignment128 = raw::fv2::ALIGNMENT_128,
+  Alignment256 = raw::fv2::ALIGNMENT_256,
+  Alignment512 = raw::fv2::ALIGNMENT_512,
+  Alignment1K = raw::fv2::ALIGNMENT_1K,
+  Alignment2K = raw::fv2::ALIGNMENT_2K,
+  Alignment4K = raw::fv2::ALIGNMENT_4K,
+  Alignment8K = raw::fv2::ALIGNMENT_8K,
+  Alignment16K = raw::fv2::ALIGNMENT_16K,
+  Alignment32K = raw::fv2::ALIGNMENT_32K,
+  Alignment64K = raw::fv2::ALIGNMENT_64K,
+  Alignment128K = raw::fv2::ALIGNMENT_128K,
+  Alignment256K = raw::fv2::ALIGNMENT_256K,
+  Alignment512K = raw::fv2::ALIGNMENT_512K,
+  Alignment1M = raw::fv2::ALIGNMENT_1M,
+  Alignment2M = raw::fv2::ALIGNMENT_2M,
+  Alignment4M = raw::fv2::ALIGNMENT_4M,
+  Alignment8M = raw::fv2::ALIGNMENT_8M,
+  Alignment16M = raw::fv2::ALIGNMENT_16M,
+  Alignment32M = raw::fv2::ALIGNMENT_32M,
+  Alignment64M = raw::fv2::ALIGNMENT_64M,
+  Alignment128M = raw::fv2::ALIGNMENT_128M,
+  Alignment256M = raw::fv2::ALIGNMENT_256M,
+  Alignment512M = raw::fv2::ALIGNMENT_512M,
+  Alignment1G = raw::fv2::ALIGNMENT_1G,
+  Alignment2G = raw::fv2::ALIGNMENT_2G,
+}

--- a/src/fw_fs/fv/file.rs
+++ b/src/fw_fs/fv/file.rs
@@ -1,0 +1,31 @@
+//! Firmware Volume File Definitions
+//!
+//! Based on the bindings and definitions in the UEFI Platform Initialization (PI)
+//! Specification V1.8A 3.1 Firmware Storage Code Definitions.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+pub type EfiFvFileAttributes = u32;
+
+pub mod raw {
+  /// Firmware File Volume File Attributes
+  /// Note: Typically named `EFI_FV_FILE_ATTRIB_*` in EDK II code.
+  pub mod attribute {
+    pub const ALIGNMENT: u32 = 0x0000001F;
+    pub const FIXED: u32 = 0x00000100;
+    pub const MEMORY_MAPPED: u32 = 0x00000200;
+  }
+}
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum Attribute {
+  Alignment = raw::attribute::ALIGNMENT,
+  Fixed = raw::attribute::FIXED,
+  MemoryMapped = raw::attribute::MEMORY_MAPPED,
+}

--- a/src/fw_fs/fvb.rs
+++ b/src/fw_fs/fvb.rs
@@ -1,0 +1,13 @@
+//! Firmware Volume Block (FVB) Definitions and Support Code
+//!
+//! Based on the values defined in the UEFI Platform Initialization (PI) Specification V1.8A Section 3.4.2
+//! Firmware Volume Block2 Protocol.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+pub mod attributes;

--- a/src/fw_fs/fvb/attributes.rs
+++ b/src/fw_fs/fvb/attributes.rs
@@ -1,0 +1,123 @@
+//! Firmware Volume Block Attributes
+//!
+//! Based on the values defined in the UEFI Platform Initialization (PI) Specification V1.8A Section 3.2.1.1
+//! EFI_FIRMWARE_VOLUME_HEADER.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+pub type EfiFvbAttributes2 = u32;
+
+/// EFI_FV_FILE_ATTRIBUTES bit definitions
+/// Note: Typically named `EFI_FVB2_*` in EDK II code.
+/// `ALIGNMENT` traditionally has the same value as `ALIGNMENT_2G`. To reduce confusion, only
+/// `ALIGNMENT_2G` is specified.
+pub mod raw {
+  pub mod fvb2 {
+    pub const READ_DISABLED_CAP: u32 = 0x00000001;
+    pub const READ_ENABLED_CAP: u32 = 0x00000002;
+    pub const READ_STATUS: u32 = 0x00000004;
+    pub const WRITE_DISABLED_CAP: u32 = 0x00000008;
+    pub const WRITE_ENABLED_CAP: u32 = 0x00000010;
+    pub const WRITE_STATUS: u32 = 0x00000020;
+    pub const LOCK_CAP: u32 = 0x00000040;
+    pub const LOCK_STATUS: u32 = 0x00000080;
+    pub const STICKY_WRITE: u32 = 0x00000200;
+    pub const MEMORY_MAPPED: u32 = 0x00000400;
+    pub const ERASE_POLARITY: u32 = 0x00000800;
+    pub const READ_LOCK_CAP: u32 = 0x00001000;
+    pub const READ_LOCK_STATUS: u32 = 0x00002000;
+    pub const WRITE_LOCK_CAP: u32 = 0x00004000;
+    pub const WRITE_LOCK_STATUS: u32 = 0x00008000;
+    pub const ALIGNMENT_1: u32 = 0x00000000;
+    pub const ALIGNMENT_2: u32 = 0x00010000;
+    pub const ALIGNMENT_4: u32 = 0x00020000;
+    pub const ALIGNMENT_8: u32 = 0x00030000;
+    pub const ALIGNMENT_16: u32 = 0x00040000;
+    pub const ALIGNMENT_32: u32 = 0x00050000;
+    pub const ALIGNMENT_64: u32 = 0x00060000;
+    pub const ALIGNMENT_128: u32 = 0x00070000;
+    pub const ALIGNMENT_256: u32 = 0x00080000;
+    pub const ALIGNMENT_512: u32 = 0x00090000;
+    pub const ALIGNMENT_1K: u32 = 0x000A0000;
+    pub const ALIGNMENT_2K: u32 = 0x000B0000;
+    pub const ALIGNMENT_4K: u32 = 0x000C0000;
+    pub const ALIGNMENT_8K: u32 = 0x000D0000;
+    pub const ALIGNMENT_16K: u32 = 0x000E0000;
+    pub const ALIGNMENT_32K: u32 = 0x000F0000;
+    pub const ALIGNMENT_64K: u32 = 0x00100000;
+    pub const ALIGNMENT_128K: u32 = 0x00110000;
+    pub const ALIGNMENT_256K: u32 = 0x00120000;
+    pub const ALIGNMENT_512K: u32 = 0x00130000;
+    pub const ALIGNMENT_1M: u32 = 0x00140000;
+    pub const ALIGNMENT_2M: u32 = 0x00150000;
+    pub const ALIGNMENT_4M: u32 = 0x00160000;
+    pub const ALIGNMENT_8M: u32 = 0x00170000;
+    pub const ALIGNMENT_16M: u32 = 0x00180000;
+    pub const ALIGNMENT_32M: u32 = 0x00190000;
+    pub const ALIGNMENT_64M: u32 = 0x001A0000;
+    pub const ALIGNMENT_128M: u32 = 0x001B0000;
+    pub const ALIGNMENT_256M: u32 = 0x001C0000;
+    pub const ALIGNMENT_512M: u32 = 0x001D0000;
+    pub const ALIGNMENT_1G: u32 = 0x001E0000;
+    pub const ALIGNMENT_2G: u32 = 0x001F0000;
+    pub const WEAK_ALIGNMENT: u32 = 0x80000000;
+  }
+}
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum Fvb2 {
+  ReadDisableCap = raw::fvb2::READ_DISABLED_CAP,
+  ReadEnableCap = raw::fvb2::READ_ENABLED_CAP,
+  ReadStatus = raw::fvb2::READ_STATUS,
+  WriteDisableCap = raw::fvb2::WRITE_DISABLED_CAP,
+  WriteEnableCap = raw::fvb2::WRITE_ENABLED_CAP,
+  WriteStatus = raw::fvb2::WRITE_STATUS,
+  LockCap = raw::fvb2::LOCK_CAP,
+  LockStatus = raw::fvb2::LOCK_STATUS,
+  StickyWrite = raw::fvb2::STICKY_WRITE,
+  MemoryMapped = raw::fvb2::MEMORY_MAPPED,
+  ErasePolarity = raw::fvb2::ERASE_POLARITY,
+  ReadLockCap = raw::fvb2::READ_LOCK_CAP,
+  ReadLockStatus = raw::fvb2::READ_LOCK_STATUS,
+  WriteLockCap = raw::fvb2::WRITE_LOCK_CAP,
+  WriteLockStatus = raw::fvb2::WRITE_LOCK_STATUS,
+  Alignment1 = raw::fvb2::ALIGNMENT_1,
+  Alignment2 = raw::fvb2::ALIGNMENT_2,
+  Alignment4 = raw::fvb2::ALIGNMENT_4,
+  Alignment8 = raw::fvb2::ALIGNMENT_8,
+  Alignment16 = raw::fvb2::ALIGNMENT_16,
+  Alignment32 = raw::fvb2::ALIGNMENT_32,
+  Alignment64 = raw::fvb2::ALIGNMENT_64,
+  Alignment128 = raw::fvb2::ALIGNMENT_128,
+  Alignment256 = raw::fvb2::ALIGNMENT_256,
+  Alignment512 = raw::fvb2::ALIGNMENT_512,
+  Alignment1K = raw::fvb2::ALIGNMENT_1K,
+  Alignment2K = raw::fvb2::ALIGNMENT_2K,
+  Alignment4K = raw::fvb2::ALIGNMENT_4K,
+  Alignment8K = raw::fvb2::ALIGNMENT_8K,
+  Alignment16K = raw::fvb2::ALIGNMENT_16K,
+  Alignment32K = raw::fvb2::ALIGNMENT_32K,
+  Alignment64K = raw::fvb2::ALIGNMENT_64K,
+  Alignment128K = raw::fvb2::ALIGNMENT_128K,
+  Alignment256K = raw::fvb2::ALIGNMENT_256K,
+  Alignment512K = raw::fvb2::ALIGNMENT_512K,
+  Alignment1M = raw::fvb2::ALIGNMENT_1M,
+  Alignment2M = raw::fvb2::ALIGNMENT_2M,
+  Alignment4M = raw::fvb2::ALIGNMENT_4M,
+  Alignment8M = raw::fvb2::ALIGNMENT_8M,
+  Alignment16M = raw::fvb2::ALIGNMENT_16M,
+  Alignment32M = raw::fvb2::ALIGNMENT_32M,
+  Alignment64M = raw::fvb2::ALIGNMENT_64M,
+  Alignment128M = raw::fvb2::ALIGNMENT_128M,
+  Alignment256M = raw::fvb2::ALIGNMENT_256M,
+  Alignment512M = raw::fvb2::ALIGNMENT_512M,
+  Alignment1G = raw::fvb2::ALIGNMENT_1G,
+  Alignment2G = raw::fvb2::ALIGNMENT_2G,
+  WeakAlignment = raw::fvb2::WEAK_ALIGNMENT,
+}

--- a/src/hob.rs
+++ b/src/hob.rs
@@ -1,0 +1,1563 @@
+//! Hand Off Block (HOB)
+//!
+//! Contains protocols defined in UEFI's Platform Initialization (PI) Specification.
+//! See <https://github.com/tianocore/edk2/blob/master/MdePkg/Include/Pi/PiHob.h>
+//!
+//! ## Example
+//! ```
+//! use mu_pi::{hob, hob::Hob, hob::HobList};
+//! use core::mem::size_of;
+//!
+//! // Generate HOBs to initialize a new HOB list
+//! fn gen_capsule() -> hob::Capsule {
+//!   let header = hob::header::Hob { r#type: hob::UEFI_CAPSULE, length: size_of::<hob::Capsule>() as u16, reserved: 0 };
+//!
+//!   hob::Capsule { header, base_address: 0, length: 0x12 }
+//! }
+//!
+//! fn gen_firmware_volume2() -> hob::FirmwareVolume2 {
+//!   let header = hob::header::Hob { r#type: hob::FV2, length: size_of::<hob::FirmwareVolume2>() as u16, reserved: 0 };
+//!
+//!   hob::FirmwareVolume2 {
+//!     header,
+//!     base_address: 0,
+//!     length: 0x0123456789abcdef,
+//!     fv_name: r_efi::efi::Guid::from_fields(1, 2, 3, 4, 5, &[6, 7, 8, 9, 10, 11]),
+//!     file_name: r_efi::efi::Guid::from_fields(1, 2, 3, 4, 5, &[6, 7, 8, 9, 10, 11]),
+//!   }
+//! }
+//!
+//! fn gen_end_of_hoblist() -> hob::PhaseHandoffInformationTable {
+//!   let header = hob::header::Hob {
+//!     r#type: hob::END_OF_HOB_LIST,
+//!     length: size_of::<hob::PhaseHandoffInformationTable>() as u16,
+//!     reserved: 0,
+//!   };
+//!
+//!   hob::PhaseHandoffInformationTable {
+//!     header,
+//!     version: 0x00010000,
+//!     boot_mode: 0,
+//!     memory_top: 0xdeadbeef,
+//!     memory_bottom: 0xdeadc0de,
+//!     free_memory_top: 104,
+//!     free_memory_bottom: 255,
+//!     end_of_hob_list: 0xdeaddeadc0dec0de,
+//!   }
+//! }
+//!
+//! // Generate some example HOBs
+//! let capsule = gen_capsule();
+//! let firmware_volume2 = gen_firmware_volume2();
+//! let end_of_hob_list = gen_end_of_hoblist();
+//!
+//! // Create a new empty HOB list
+//! let mut hoblist = HobList::new();
+//!
+//! // Push the example HOBs onto the HOB list
+//! hoblist.push(Hob::Capsule(&capsule));
+//! hoblist.push(Hob::FirmwareVolume2(&firmware_volume2));
+//! hoblist.push(Hob::Handoff(&end_of_hob_list));
+//! ```
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+use crate::address_helper::{align_down, align_up};
+use core::{
+  ffi::c_void,
+  fmt,
+  marker::PhantomData,
+  mem::{self, size_of},
+};
+use indoc::indoc;
+
+// Expectation is someone will provide alloc
+extern crate alloc;
+use alloc::vec::Vec;
+
+// If the target is x86_64, then EfiPhysicalAddress is u64
+#[cfg(target_arch = "x86_64")]
+pub type EfiPhysicalAddress = u64;
+
+// If the target is aarch64, then EfiPhysicalAddress is u64
+#[cfg(target_arch = "aarch64")]
+pub type EfiPhysicalAddress = u64;
+
+// if the target is x86, then EfiPhysicalAddress is u32
+#[cfg(target_arch = "x86")]
+pub type EfiPhysicalAddress = u32;
+
+// if the target is not x86, x86_64, or aarch64, then alert the user
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
+compile_error!("This crate only (currently) supports x86, x86_64, and aarch64 architectures");
+
+// All targets assume (currently) that EfiBootMode is u32
+pub type EfiBootMode = u32;
+
+// HOB type field is a UINT16
+pub const HANDOFF: u16 = 0x0001;
+pub const MEMORY_ALLOCATION: u16 = 0x0002;
+pub const RESOURCE_DESCRIPTOR: u16 = 0x0003;
+pub const GUID_EXTENSION: u16 = 0x0004;
+pub const FV: u16 = 0x0005;
+pub const CPU: u16 = 0x0006;
+pub const MEMORY_POOL: u16 = 0x0007;
+pub const FV2: u16 = 0x0009;
+pub const LOAD_PEIM_UNUSED: u16 = 0x000A;
+pub const UEFI_CAPSULE: u16 = 0x000B;
+pub const FV3: u16 = 0x000C;
+pub const UNUSED: u16 = 0xFFFE;
+pub const END_OF_HOB_LIST: u16 = 0xFFFF;
+
+pub mod header {
+  use crate::hob::EfiPhysicalAddress;
+  use r_efi::system::MemoryType;
+
+  /// Describes the format and size of the data inside the HOB.
+  /// All HOBs must contain this generic HOB header (EFI_HOB_GENERIC_HEADER).
+  ///
+  #[repr(C)]
+  #[derive(Copy, Clone, Debug)]
+  pub struct Hob {
+    // EFI_HOB_GENERIC_HEADER
+    /// Identifies the HOB data structure type.
+    ///
+    pub r#type: u16,
+
+    /// The length in bytes of the HOB.
+    ///
+    pub length: u16,
+
+    /// This field must always be set to zero.
+    ///
+    pub reserved: u32,
+  }
+
+  /// MemoryAllocation (EFI_HOB_MEMORY_ALLOCATION_HEADER) describes the
+  /// various attributes of the logical memory allocation. The type field will be used for
+  /// subsequent inclusion in the UEFI memory map.
+  ///
+  #[repr(C)]
+  #[derive(Copy, Clone, Debug)]
+  pub struct MemoryAllocation {
+    // EFI_HOB_MEMORY_ALLOCATION_HEADER
+    /// A GUID that defines the memory allocation region's type and purpose, as well as
+    /// other fields within the memory allocation HOB. This GUID is used to define the
+    /// additional data within the HOB that may be present for the memory allocation HOB.
+    /// Type EFI_GUID is defined in InstallProtocolInterface() in the UEFI 2.0
+    /// specification.
+    ///
+    pub name: r_efi::base::Guid,
+
+    /// The base address of memory allocated by this HOB. Type
+    /// EfiPhysicalAddress is defined in AllocatePages() in the UEFI 2.0
+    /// specification.
+    ///
+    pub memory_base_address: EfiPhysicalAddress,
+
+    /// The length in bytes of memory allocated by this HOB.
+    ///
+    pub memory_length: u64,
+
+    /// Defines the type of memory allocated by this HOB. The memory type definition
+    /// follows the EFI_MEMORY_TYPE definition. Type EFI_MEMORY_TYPE is defined
+    /// in AllocatePages() in the UEFI 2.0 specification.
+    ///
+    pub memory_type: MemoryType,
+
+    /// This field will always be set to zero.
+    ///
+    pub reserved: [u8; 4],
+  }
+}
+
+/// Describes pool memory allocations.
+///
+/// The HOB generic header. Header.HobType = EFI_HOB_TYPE_MEMORY_POOL.
+///
+pub type MemoryPool = header::Hob;
+
+/// Contains general state information used by the HOB producer phase.
+/// This HOB must be the first one in the HOB list.
+///
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct PhaseHandoffInformationTable {
+  /// The HOB generic header. Header.HobType = EFI_HOB_TYPE_HANDOFF.
+  ///
+  pub header: header::Hob, // EFI_HOB_GENERIC_HEADER
+
+  /// The version number pertaining to the PHIT HOB definition.
+  /// This value is four bytes in length to provide an 8-byte aligned entry
+  /// when it is combined with the 4-byte BootMode.
+  ///
+  pub version: u32,
+
+  /// The system boot mode as determined during the HOB producer phase.
+  ///
+  pub boot_mode: EfiBootMode,
+
+  /// The highest address location of memory that is allocated for use by the HOB producer
+  /// phase. This address must be 4-KB aligned to meet page restrictions of UEFI.
+  ///
+  pub memory_top: EfiPhysicalAddress,
+
+  /// The lowest address location of memory that is allocated for use by the HOB producer phase.
+  ///
+  pub memory_bottom: EfiPhysicalAddress,
+
+  /// The highest address location of free memory that is currently available
+  /// for use by the HOB producer phase.
+  ///
+  pub free_memory_top: EfiPhysicalAddress,
+
+  /// The lowest address location of free memory that is available for use by the HOB producer phase.
+  ///
+  pub free_memory_bottom: EfiPhysicalAddress,
+
+  /// The end of the HOB list.
+  ///
+  pub end_of_hob_list: EfiPhysicalAddress,
+}
+
+/// Describes all memory ranges used during the HOB producer
+/// phase that exist outside the HOB list. This HOB type
+/// describes how memory is used, not the physical attributes of memory.
+///
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct MemoryAllocation {
+  // EFI_HOB_MEMORY_ALLOCATION
+  /// The HOB generic header. Header.HobType = EFI_HOB_TYPE_MEMORY_ALLOCATION.
+  ///
+  pub header: header::Hob,
+
+  /// An instance of the EFI_HOB_MEMORY_ALLOCATION_HEADER that describes the
+  /// various attributes of the logical memory allocation.
+  ///
+  pub alloc_descriptor: header::MemoryAllocation,
+  // Additional data pertaining to the "Name" Guid memory
+  // may go here.
+  //
+}
+
+// EFI_HOB_MEMORY_ALLOCATION_STACK
+/// Describes the memory stack that is produced by the HOB producer
+/// phase and upon which all post-memory-installed executable
+/// content in the HOB producer phase is executing.
+///
+pub type MemoryAllocationStack = MemoryAllocation;
+
+// EFI_HOB_MEMORY_ALLOCATION_BSP_STORE
+/// Defines the location of the boot-strap
+/// processor (BSP) BSPStore ("Backing Store Pointer Store").
+/// This HOB is valid for the Itanium processor family only
+/// register overflow store.
+///
+pub type MemoryAllocationBspStore = MemoryAllocation;
+
+/// Defines the location and entry point of the HOB consumer phase.
+///
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct MemoryAllocationModule {
+  /// The HOB generic header. Header.HobType = EFI_HOB_TYPE_MEMORY_ALLOCATION.
+  ///
+  pub header: header::Hob,
+
+  /// An instance of the EFI_HOB_MEMORY_ALLOCATION_HEADER that describes the
+  /// various attributes of the logical memory allocation.
+  ///
+  pub alloc_descriptor: header::MemoryAllocation,
+
+  /// The GUID specifying the values of the firmware file system name
+  /// that contains the HOB consumer phase component.
+  ///
+  pub module_name: r_efi::base::Guid, // EFI_GUID
+
+  /// The address of the memory-mapped firmware volume
+  /// that contains the HOB consumer phase firmware file.
+  ///
+  pub entry_point: u64, // EFI_PHYSICAL_ADDRESS
+}
+
+//
+// Value of ResourceType in EFI_HOB_RESOURCE_DESCRIPTOR.
+//
+pub const EFI_RESOURCE_SYSTEM_MEMORY: u32 = 0x00000000;
+pub const EFI_RESOURCE_MEMORY_MAPPED_IO: u32 = 0x00000001;
+pub const EFI_RESOURCE_IO: u32 = 0x00000002;
+pub const EFI_RESOURCE_FIRMWARE_DEVICE: u32 = 0x00000003;
+pub const EFI_RESOURCE_MEMORY_MAPPED_IO_PORT: u32 = 0x00000004;
+pub const EFI_RESOURCE_MEMORY_RESERVED: u32 = 0x00000005;
+pub const EFI_RESOURCE_IO_RESERVED: u32 = 0x00000006;
+
+//
+// BZ3937_EFI_RESOURCE_MEMORY_UNACCEPTED is defined for unaccepted memory.
+// But this definition has not been officially in the PI spec. Base
+// on the code-first we define BZ3937_EFI_RESOURCE_MEMORY_UNACCEPTED at
+// MdeModulePkg/Include/Pi/PrePiHob.h and update EFI_RESOURCE_MAX_MEMORY_TYPE
+// to 8. After BZ3937_EFI_RESOURCE_MEMORY_UNACCEPTED is officially published
+// in PI spec, we will re-visit here.
+//
+// #define BZ3937_EFI_RESOURCE_MEMORY_UNACCEPTED      0x00000007
+pub const EFI_RESOURCE_MAX_MEMORY_TYPE: u32 = 0x00000007;
+
+//
+// These types can be ORed together as needed.
+//
+// The following attributes are used to describe settings
+//
+pub const EFI_RESOURCE_ATTRIBUTE_PRESENT: u32 = 0x00000001;
+pub const EFI_RESOURCE_ATTRIBUTE_INITIALIZED: u32 = 0x00000002;
+pub const EFI_RESOURCE_ATTRIBUTE_TESTED: u32 = 0x00000004;
+pub const EFI_RESOURCE_ATTRIBUTE_READ_PROTECTED: u32 = 0x00000080;
+
+//
+// This is typically used as memory cacheability attribute today.
+// NOTE: Since PI spec 1.4, please use EFI_RESOURCE_ATTRIBUTE_READ_ONLY_PROTECTED
+// as Physical write protected attribute, and EFI_RESOURCE_ATTRIBUTE_WRITE_PROTECTED
+// means Memory cacheability attribute: The memory supports being programmed with
+// a writeprotected cacheable attribute.
+//
+pub const EFI_RESOURCE_ATTRIBUTE_WRITE_PROTECTED: u32 = 0x00000100;
+pub const EFI_RESOURCE_ATTRIBUTE_EXECUTION_PROTECTED: u32 = 0x00000200;
+pub const EFI_RESOURCE_ATTRIBUTE_PERSISTENT: u32 = 0x00800000;
+
+//
+// Physical memory relative reliability attribute. This
+// memory provides higher reliability relative to other
+// memory in the system. If all memory has the same
+// reliability, then this bit is not used.
+//
+pub const EFI_RESOURCE_ATTRIBUTE_MORE_RELIABLE: u32 = 0x02000000;
+
+//
+// The rest of the attributes are used to describe capabilities
+//
+pub const EFI_RESOURCE_ATTRIBUTE_SINGLE_BIT_ECC: u32 = 0x00000008;
+pub const EFI_RESOURCE_ATTRIBUTE_MULTIPLE_BIT_ECC: u32 = 0x00000010;
+pub const EFI_RESOURCE_ATTRIBUTE_ECC_RESERVED_1: u32 = 0x00000020;
+pub const EFI_RESOURCE_ATTRIBUTE_ECC_RESERVED_2: u32 = 0x00000040;
+pub const EFI_RESOURCE_ATTRIBUTE_UNCACHEABLE: u32 = 0x00000400;
+pub const EFI_RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE: u32 = 0x00000800;
+pub const EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE: u32 = 0x00001000;
+pub const EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE: u32 = 0x00002000;
+pub const EFI_RESOURCE_ATTRIBUTE_16_BIT_IO: u32 = 0x00004000;
+pub const EFI_RESOURCE_ATTRIBUTE_32_BIT_IO: u32 = 0x00008000;
+pub const EFI_RESOURCE_ATTRIBUTE_64_BIT_IO: u32 = 0x00010000;
+pub const EFI_RESOURCE_ATTRIBUTE_UNCACHED_EXPORTED: u32 = 0x00020000;
+pub const EFI_RESOURCE_ATTRIBUTE_READ_PROTECTABLE: u32 = 0x00100000;
+
+//
+// This is typically used as memory cacheability attribute today.
+// NOTE: Since PI spec 1.4, please use EFI_RESOURCE_ATTRIBUTE_READ_ONLY_PROTECTABLE
+// as Memory capability attribute: The memory supports being protected from processor
+// writes, and EFI_RESOURCE_ATTRIBUTE_WRITE_PROTECTABLE TABLE means Memory cacheability attribute:
+// The memory supports being programmed with a writeprotected cacheable attribute.
+//
+pub const EFI_RESOURCE_ATTRIBUTE_WRITE_PROTECTABLE: u32 = 0x00200000;
+pub const EFI_RESOURCE_ATTRIBUTE_EXECUTION_PROTECTABLE: u32 = 0x00400000;
+pub const EFI_RESOURCE_ATTRIBUTE_PERSISTABLE: u32 = 0x01000000;
+
+pub const EFI_RESOURCE_ATTRIBUTE_READ_ONLY_PROTECTED: u32 = 0x00040000;
+pub const EFI_RESOURCE_ATTRIBUTE_READ_ONLY_PROTECTABLE: u32 = 0x00080000;
+
+pub const MEMORY_ATTRIBUTE_MASK: u32 = EFI_RESOURCE_ATTRIBUTE_PRESENT
+  | EFI_RESOURCE_ATTRIBUTE_INITIALIZED
+  | EFI_RESOURCE_ATTRIBUTE_TESTED
+  | EFI_RESOURCE_ATTRIBUTE_READ_PROTECTED
+  | EFI_RESOURCE_ATTRIBUTE_WRITE_PROTECTED
+  | EFI_RESOURCE_ATTRIBUTE_EXECUTION_PROTECTED
+  | EFI_RESOURCE_ATTRIBUTE_READ_ONLY_PROTECTED
+  | EFI_RESOURCE_ATTRIBUTE_16_BIT_IO
+  | EFI_RESOURCE_ATTRIBUTE_32_BIT_IO
+  | EFI_RESOURCE_ATTRIBUTE_64_BIT_IO
+  | EFI_RESOURCE_ATTRIBUTE_PERSISTENT;
+
+pub const TESTED_MEMORY_ATTRIBUTES: u32 =
+  EFI_RESOURCE_ATTRIBUTE_PRESENT | EFI_RESOURCE_ATTRIBUTE_INITIALIZED | EFI_RESOURCE_ATTRIBUTE_TESTED;
+
+pub const INITIALIZED_MEMORY_ATTRIBUTES: u32 = EFI_RESOURCE_ATTRIBUTE_PRESENT | EFI_RESOURCE_ATTRIBUTE_INITIALIZED;
+
+pub const PRESENT_MEMORY_ATTRIBUTES: u32 = EFI_RESOURCE_ATTRIBUTE_PRESENT;
+
+/// Attributes for reserved memory before it is promoted to system memory
+pub const EFI_MEMORY_PRESENT: u64 = 0x0100_0000_0000_0000;
+pub const EFI_MEMORY_INITIALIZED: u64 = 0x0200_0000_0000_0000;
+pub const EFI_MEMORY_TESTED: u64 = 0x0400_0000_0000_0000;
+
+///
+/// Physical memory persistence attribute.
+/// The memory region supports byte-addressable non-volatility.
+///
+pub const EFI_MEMORY_NV: u64 = 0x0000_0000_0000_8000;
+///
+/// The memory region provides higher reliability relative to other memory in the system.
+/// If all memory has the same reliability, then this bit is not used.
+///
+pub const EFI_MEMORY_MORE_RELIABLE: u64 = 0x0000_0000_0001_0000;
+
+/// Describes the resource properties of all fixed,
+/// nonrelocatable resource ranges found on the processor
+/// host bus during the HOB producer phase.
+///
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct ResourceDescriptor {
+  // EFI_HOB_RESOURCE_DESCRIPTOR
+  /// The HOB generic header. Header.HobType = EFI_HOB_TYPE_RESOURCE_DESCRIPTOR.
+  ///
+  pub header: header::Hob,
+
+  /// A GUID representing the owner of the resource. This GUID is used by HOB
+  /// consumer phase components to correlate device ownership of a resource.
+  ///
+  pub owner: r_efi::base::Guid,
+
+  /// The resource type enumeration as defined by EFI_RESOURCE_TYPE.
+  ///
+  pub resource_type: u32,
+
+  /// Resource attributes as defined by EFI_RESOURCE_ATTRIBUTE_TYPE.
+  ///
+  pub resource_attribute: u32,
+
+  /// The physical start address of the resource region.
+  ///
+  pub physical_start: EfiPhysicalAddress,
+
+  /// The number of bytes of the resource region.
+  ///
+  pub resource_length: u64,
+}
+
+impl ResourceDescriptor {
+  pub fn attributes_valid(&self) -> bool {
+    (self.resource_attribute & EFI_RESOURCE_ATTRIBUTE_READ_PROTECTED == 0
+      || self.resource_attribute & EFI_RESOURCE_ATTRIBUTE_READ_ONLY_PROTECTABLE != 0)
+      && (self.resource_attribute & EFI_RESOURCE_ATTRIBUTE_WRITE_PROTECTED == 0
+        || self.resource_attribute & EFI_RESOURCE_ATTRIBUTE_WRITE_PROTECTABLE != 0)
+      && (self.resource_attribute & EFI_RESOURCE_ATTRIBUTE_EXECUTION_PROTECTED == 0
+        || self.resource_attribute & EFI_RESOURCE_ATTRIBUTE_EXECUTION_PROTECTABLE != 0)
+      && (self.resource_attribute & EFI_RESOURCE_ATTRIBUTE_READ_ONLY_PROTECTED == 0
+        || self.resource_attribute & EFI_RESOURCE_ATTRIBUTE_READ_ONLY_PROTECTABLE != 0)
+      && (self.resource_attribute & EFI_RESOURCE_ATTRIBUTE_PERSISTENT == 0
+        || self.resource_attribute & EFI_RESOURCE_ATTRIBUTE_PERSISTABLE != 0)
+  }
+}
+
+/// Allows writers of executable content in the HOB producer phase to
+/// maintain and manage HOBs with specific GUID.
+///
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct GuidHob {
+  // EFI_HOB_GUID_TYPE
+  /// The HOB generic header. Header.HobType = EFI_HOB_TYPE_GUID_EXTENSION.
+  ///
+  pub header: header::Hob,
+
+  /// A GUID that defines the contents of this HOB.
+  ///
+  pub name: r_efi::base::Guid,
+  // Guid specific data goes here
+  //
+}
+
+/// Details the location of firmware volumes that contain firmware files.
+///
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct FirmwareVolume {
+  // EFI_HOB_FIRMWARE_VOLUME
+  /// The HOB generic header. Header.HobType = EFI_HOB_TYPE_FV.
+  ///
+  pub header: header::Hob,
+
+  /// The physical memory-mapped base address of the firmware volume.
+  ///
+  pub base_address: EfiPhysicalAddress,
+
+  /// The length in bytes of the firmware volume.
+  ///
+  pub length: u64,
+}
+
+/// Details the location of a firmware volume that was extracted
+/// from a file within another firmware volume.
+///
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct FirmwareVolume2 {
+  // EFI_HOB_FIRMWARE_VOLUME2
+  /// The HOB generic header. Header.HobType = EFI_HOB_TYPE_FV2.
+  ///
+  pub header: header::Hob,
+
+  /// The physical memory-mapped base address of the firmware volume.
+  ///
+  pub base_address: EfiPhysicalAddress,
+
+  /// The length in bytes of the firmware volume.
+  ///
+  pub length: u64,
+
+  /// The name of the firmware volume.
+  ///
+  pub fv_name: r_efi::base::Guid,
+
+  /// The name of the firmware file that contained this firmware volume.
+  ///
+  pub file_name: r_efi::base::Guid,
+}
+
+/// Details the location of a firmware volume that was extracted
+/// from a file within another firmware volume.
+///
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct FirmwareVolume3 {
+  // EFI_HOB_FIRMWARE_VOLUME3
+  /// The HOB generic header. Header.HobType = EFI_HOB_TYPE_FV3.
+  ///
+  pub header: header::Hob,
+
+  /// The physical memory-mapped base address of the firmware volume.
+  ///
+  pub base_address: EfiPhysicalAddress,
+
+  /// The length in bytes of the firmware volume.
+  ///
+  pub length: u64,
+
+  /// The authentication status.
+  ///
+  pub authentication_status: u32,
+
+  /// TRUE if the FV was extracted as a file within another firmware volume.
+  /// FALSE otherwise.
+  ///
+  pub extracted_fv: r_efi::efi::Boolean,
+
+  /// The name of the firmware volume.
+  /// Valid only if IsExtractedFv is TRUE.
+  ///
+  pub fv_name: r_efi::base::Guid,
+
+  /// The name of the firmware file that contained this firmware volume.
+  /// Valid only if IsExtractedFv is TRUE.
+  ///
+  pub file_name: r_efi::base::Guid,
+}
+
+/// Describes processor information, such as address space and I/O space capabilities.
+///
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct Cpu {
+  // EFI_HOB_CPU
+  /// The HOB generic header. Header.HobType = EFI_HOB_TYPE_CPU.
+  ///
+  pub header: header::Hob,
+
+  /// Identifies the maximum physical memory addressability of the processor.
+  ///
+  pub size_of_memory_space: u8,
+
+  /// Identifies the maximum physical I/O addressability of the processor.
+  ///
+  pub size_of_io_space: u8,
+
+  /// This field will always be set to zero.
+  ///
+  pub reserved: [u8; 6],
+}
+
+/// Each UEFI capsule HOB details the location of a UEFI capsule. It includes a base address and length
+/// which is based upon memory blocks with a EFI_CAPSULE_HEADER and the associated
+/// CapsuleImageSize-based payloads. These HOB's shall be created by the PEI PI firmware
+/// sometime after the UEFI UpdateCapsule service invocation with the
+/// CAPSULE_FLAGS_POPULATE_SYSTEM_TABLE flag set in the EFI_CAPSULE_HEADER.
+///
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct Capsule {
+  // EFI_HOB_CAPSULE
+  /// The HOB generic header where Header.HobType = EFI_HOB_TYPE_UEFI_CAPSULE.
+  ///
+  pub header: header::Hob,
+
+  /// The physical memory-mapped base address of an UEFI capsule. This value is set to
+  /// point to the base of the contiguous memory of the UEFI capsule.
+  /// The length of the contiguous memory in bytes.
+  ///
+  pub base_address: u8,
+  pub length: u8,
+}
+
+/// Represents a HOB list.
+///
+pub struct HobList<'a>(Vec<Hob<'a>>);
+
+impl Default for HobList<'_> {
+  fn default() -> Self {
+    HobList::new()
+  }
+}
+
+/// Union of all the possible HOB Types.
+///
+#[derive(Clone, Debug)]
+pub enum Hob<'a> {
+  Handoff(&'a PhaseHandoffInformationTable),
+  MemoryAllocation(&'a MemoryAllocation),
+  MemoryAllocationModule(&'a MemoryAllocationModule),
+  Capsule(&'a Capsule),
+  ResourceDescriptor(&'a ResourceDescriptor),
+  GuidHob(&'a GuidHob),
+  FirmwareVolume(&'a FirmwareVolume),
+  FirmwareVolume2(&'a FirmwareVolume2),
+  FirmwareVolume3(&'a FirmwareVolume3),
+  Cpu(&'a Cpu),
+  Misc(u16),
+}
+
+pub trait HobTrait {
+  fn size(&self) -> usize;
+  fn as_ptr<T>(&self) -> *const T;
+}
+
+// HOB Trait implementation.
+impl HobTrait for Hob<'_> {
+  /// Returns the size of the HOB.
+  fn size(&self) -> usize {
+    match self {
+      Hob::Handoff(_) => size_of::<PhaseHandoffInformationTable>(),
+      Hob::MemoryAllocation(_) => size_of::<MemoryAllocation>(),
+      Hob::MemoryAllocationModule(_) => size_of::<MemoryAllocationModule>(),
+      Hob::Capsule(_) => size_of::<Capsule>(),
+      Hob::ResourceDescriptor(_) => size_of::<ResourceDescriptor>(),
+      Hob::GuidHob(_) => size_of::<GuidHob>(),
+      Hob::FirmwareVolume(_) => size_of::<FirmwareVolume>(),
+      Hob::FirmwareVolume2(_) => size_of::<FirmwareVolume2>(),
+      Hob::FirmwareVolume3(_) => size_of::<FirmwareVolume3>(),
+      Hob::Cpu(_) => size_of::<Cpu>(),
+      Hob::Misc(_) => size_of::<u16>(),
+    }
+  }
+
+  /// Returns a pointer to the HOB.
+  fn as_ptr<T>(&self) -> *const T {
+    match self {
+      Hob::Handoff(hob) => *hob as *const PhaseHandoffInformationTable as *const _,
+      Hob::MemoryAllocation(hob) => *hob as *const MemoryAllocation as *const _,
+      Hob::MemoryAllocationModule(hob) => *hob as *const MemoryAllocationModule as *const _,
+      Hob::Capsule(hob) => *hob as *const Capsule as *const _,
+      Hob::ResourceDescriptor(hob) => *hob as *const ResourceDescriptor as *const _,
+      Hob::GuidHob(hob) => *hob as *const GuidHob as *const _,
+      Hob::FirmwareVolume(hob) => *hob as *const FirmwareVolume as *const _,
+      Hob::FirmwareVolume2(hob) => *hob as *const FirmwareVolume2 as *const _,
+      Hob::FirmwareVolume3(hob) => *hob as *const FirmwareVolume3 as *const _,
+      Hob::Cpu(hob) => *hob as *const Cpu as *const _,
+      Hob::Misc(hob) => *hob as *const u16 as *const _,
+    }
+  }
+}
+
+impl<'a> HobList<'a> {
+  /// Instantiates a Hoblist.
+  pub fn new() -> Self {
+    HobList(Vec::new())
+  }
+
+  /// Implements iter for Hoblist.
+  ///
+  /// # Example(s)
+  ///
+  /// ```no_run
+  /// use core::ffi::c_void;
+  /// use mu_pi::hob::HobList;
+  ///
+  /// fn example(hob_list: *const c_void) {
+  ///     // example discovering and adding hobs to a hob list
+  ///     let mut the_hob_list = HobList::default();
+  ///     the_hob_list.discover_hobs(hob_list);
+  ///
+  ///     for hob in the_hob_list.iter() {
+  ///         // ... do something with the hob(s)
+  ///     }
+  /// }
+  /// ```
+  pub fn iter(&self) -> impl Iterator<Item = &Hob> {
+    self.0.iter()
+  }
+
+  /// Returns the size of the Hoblist in bytes.
+  ///
+  /// # Example(s)
+  ///
+  /// ```no_run
+  /// use core::ffi::c_void;
+  /// use mu_pi::hob::HobList;
+  ///
+  /// fn example(hob_list: *const c_void) {
+  ///     // example discovering and adding hobs to a hob list
+  ///     let mut the_hob_list = HobList::default();
+  ///     the_hob_list.discover_hobs(hob_list);
+  ///
+  ///     let length = the_hob_list.size();
+  ///     println!("size_of_hobs: {:?}", length);
+  /// }
+  pub fn size(&self) -> usize {
+    let mut size_of_hobs = 0;
+
+    for hob in self.iter() {
+      size_of_hobs += hob.size()
+    }
+
+    size_of_hobs
+  }
+
+  /// Implements len for Hoblist.
+  /// Returns the number of hobs in the list.
+  ///
+  /// # Example(s)
+  /// ```no_run
+  /// use core::ffi::c_void;
+  /// use mu_pi::hob::HobList;
+  ///
+  /// fn example(hob_list: *const c_void) {
+  ///    // example discovering and adding hobs to a hob list
+  ///    let mut the_hob_list = HobList::default();
+  ///    the_hob_list.discover_hobs(hob_list);
+  ///
+  ///    let length = the_hob_list.len();
+  ///    println!("length_of_hobs: {:?}", length);
+  /// }
+  /// ```
+  pub fn len(&self) -> usize {
+    self.0.len()
+  }
+
+  /// Implements is_empty for Hoblist.
+  /// Returns true if the list is empty.
+  ///
+  /// # Example(s)
+  /// ```no_run
+  /// use core::ffi::c_void;
+  /// use mu_pi::hob::HobList;
+  ///
+  /// fn example(hob_list: *const c_void) {
+  ///    // example discovering and adding hobs to a hob list
+  ///    let mut the_hob_list = HobList::default();
+  ///    the_hob_list.discover_hobs(hob_list);
+  ///
+  ///    let is_empty = the_hob_list.is_empty();
+  ///    println!("is_empty: {:?}", is_empty);
+  /// }
+  /// ```
+  pub fn is_empty(&self) -> bool {
+    self.0.is_empty()
+  }
+
+  /// Implements push for Hoblist.
+  ///
+  /// Parameters:
+  /// * hob: Hob<'a> - the hob to add to the list
+  ///
+  /// # Example(s)
+  /// ```no_run
+  /// use core::{ffi::c_void, mem::size_of};
+  /// use mu_pi::hob::{HobList, Hob, header, FirmwareVolume, FV};
+  ///
+  /// fn example(hob_list: *const c_void) {
+  ///   // example discovering and adding hobs to a hob list
+  ///   let mut the_hob_list = HobList::default();
+  ///   the_hob_list.discover_hobs(hob_list);
+  ///
+  ///   // example pushing a hob onto the list
+  ///   let header = header::Hob {
+  ///       r#type: FV,
+  ///       length: size_of::<FirmwareVolume>() as u16,
+  ///       reserved: 0,
+  ///   };
+  ///
+  ///   let firmware_volume = FirmwareVolume {
+  ///       header,
+  ///       base_address: 0,
+  ///       length: 0x0123456789abcdef,
+  ///   };
+  ///
+  ///   let hob = Hob::FirmwareVolume(&firmware_volume);
+  ///   the_hob_list.push(hob);
+  /// }
+  /// ```
+  pub fn push(&mut self, hob: Hob<'a>) {
+    let cloned_hob = hob.clone();
+    self.0.push(cloned_hob);
+  }
+
+  /// Discovers hobs from a C style void* and adds them to a rust structure.
+  ///
+  /// # Example(s)
+  ///
+  /// ```no_run
+  /// use core::ffi::c_void;
+  /// use mu_pi::hob::HobList;
+  ///
+  /// fn example(hob_list: *const c_void) {
+  ///     // example discovering and adding hobs to a hob list
+  ///     let mut the_hob_list = HobList::default();
+  ///     the_hob_list.discover_hobs(hob_list);
+  /// }
+  /// ```
+  pub fn discover_hobs(&mut self, hob_list: *const c_void) {
+    const NOT_NULL: &str = "Ptr should not be NULL";
+    fn assert_hob_size<T>(hob: &header::Hob) {
+      let hob_len = hob.length as usize;
+      let hob_size = mem::size_of::<T>();
+      assert_eq!(hob_len, hob_size, "Trying to cast hob of length {hob_len} into a pointer of size {hob_size}");
+    }
+
+    let mut hob_header: *const header::Hob = hob_list as *const header::Hob;
+
+    loop {
+      let current_header = unsafe { hob_header.cast::<header::Hob>().as_ref().expect(NOT_NULL) };
+      match current_header.r#type {
+        HANDOFF => {
+          assert_hob_size::<PhaseHandoffInformationTable>(current_header);
+          let phit_hob = unsafe { hob_header.cast::<PhaseHandoffInformationTable>().as_ref().expect(NOT_NULL) };
+          self.0.push(Hob::Handoff(phit_hob));
+        }
+        MEMORY_ALLOCATION => {
+          if current_header.length == mem::size_of::<MemoryAllocationModule>() as u16 {
+            let mem_alloc_hob = unsafe { hob_header.cast::<MemoryAllocationModule>().as_ref().expect(NOT_NULL) };
+            self.0.push(Hob::MemoryAllocationModule(mem_alloc_hob));
+          } else {
+            assert_hob_size::<MemoryAllocation>(current_header);
+            let mem_alloc_hob = unsafe { hob_header.cast::<MemoryAllocation>().as_ref().expect(NOT_NULL) };
+            self.0.push(Hob::MemoryAllocation(mem_alloc_hob));
+          }
+        }
+        RESOURCE_DESCRIPTOR => {
+          assert_hob_size::<ResourceDescriptor>(current_header);
+          let resource_desc_hob = unsafe { hob_header.cast::<ResourceDescriptor>().as_ref().expect(NOT_NULL) };
+          self.0.push(Hob::ResourceDescriptor(resource_desc_hob));
+        }
+        GUID_EXTENSION => {
+          let guid_hob = unsafe { hob_header.cast::<GuidHob>().as_ref().expect(NOT_NULL) };
+          self.0.push(Hob::GuidHob(guid_hob));
+        }
+        FV => {
+          assert_hob_size::<FirmwareVolume>(current_header);
+          let fv_hob = unsafe { hob_header.cast::<FirmwareVolume>().as_ref().expect(NOT_NULL) };
+          self.0.push(Hob::FirmwareVolume(fv_hob));
+        }
+        FV2 => {
+          assert_hob_size::<FirmwareVolume2>(current_header);
+          let fv2_hob = unsafe { hob_header.cast::<FirmwareVolume2>().as_ref().expect(NOT_NULL) };
+          self.0.push(Hob::FirmwareVolume2(fv2_hob));
+        }
+        FV3 => {
+          assert_hob_size::<FirmwareVolume3>(current_header);
+          let fv3_hob = unsafe { hob_header.cast::<FirmwareVolume3>().as_ref().expect(NOT_NULL) };
+          self.0.push(Hob::FirmwareVolume3(fv3_hob));
+        }
+        CPU => {
+          assert_hob_size::<Cpu>(current_header);
+          let cpu_hob = unsafe { hob_header.cast::<Cpu>().as_ref().expect(NOT_NULL) };
+          self.0.push(Hob::Cpu(cpu_hob));
+        }
+        UEFI_CAPSULE => {
+          assert_hob_size::<Capsule>(current_header);
+          let capsule_hob = unsafe { hob_header.cast::<Capsule>().as_ref().expect(NOT_NULL) };
+          self.0.push(Hob::Capsule(capsule_hob));
+        }
+        END_OF_HOB_LIST => {
+          break;
+        }
+        _ => {
+          self.0.push(Hob::Misc(current_header.r#type));
+        }
+      }
+      let next_hob = hob_header as usize + current_header.length as usize;
+      hob_header = next_hob as *const header::Hob;
+    }
+  }
+}
+
+/// Implements IntoIterator for HobList.
+///
+/// Defines how it will be converted to an iterator.
+impl<'a> IntoIterator for HobList<'a> {
+  type Item = Hob<'a>;
+  type IntoIter = <Vec<Hob<'a>> as IntoIterator>::IntoIter;
+
+  fn into_iter(self) -> Self::IntoIter {
+    self.0.into_iter()
+  }
+}
+
+/// Implements Debug for Hoblist.
+///
+/// Writes Hoblist debug information to stdio
+///
+impl fmt::Debug for HobList<'_> {
+  #[cfg_attr(feature = "nightly", feature(no_coverage))]
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    for hob in self.0.clone().into_iter() {
+      match hob {
+        Hob::Handoff(hob) => {
+          write!(
+            f,
+            indoc! {"
+                        PHASE HANDOFF INFORMATION TABLE (PHIT) HOB
+                          HOB Length: 0x{:x}
+                          Version: 0x{:x}
+                          Boot Mode: 0x{:x}
+                          Memory Bottom: 0x{:x}
+                          Memory Top: 0x{:x}
+                          Free Memory Bottom: 0x{:x}
+                          Free Memory Top: 0x{:x}
+                          End of HOB List: 0x{:x}\n"},
+            hob.header.length,
+            hob.version,
+            hob.boot_mode,
+            align_up(hob.memory_bottom, 0x1000),
+            align_down(hob.memory_top, 0x1000),
+            align_up(hob.free_memory_bottom, 0x1000),
+            align_down(hob.free_memory_top, 0x1000),
+            hob.end_of_hob_list
+          )?;
+        }
+        Hob::MemoryAllocation(hob) => {
+          write!(
+            f,
+            indoc! {"
+                        MEMORY ALLOCATION HOB
+                          HOB Length: 0x{:x}
+                          Memory Base Address: 0x{:x}
+                          Memory Length: 0x{:x}
+                          Memory Type: {:?}\n"},
+            hob.header.length,
+            hob.alloc_descriptor.memory_base_address,
+            hob.alloc_descriptor.memory_length,
+            hob.alloc_descriptor.memory_type
+          )?;
+        }
+        Hob::ResourceDescriptor(hob) => {
+          write!(
+            f,
+            indoc! {"
+                        RESOURCE DESCRIPTOR HOB
+                          HOB Length: 0x{:x}
+                          Resource Type: 0x{:x}
+                          Resource Attribute Type: 0x{:x}
+                          Resource Start Address: 0x{:x}
+                          Resource Length: 0x{:x}\n"},
+            hob.header.length, hob.resource_type, hob.resource_attribute, hob.physical_start, hob.resource_length
+          )?;
+        }
+        Hob::GuidHob(hob) => {
+          write!(
+            f,
+            indoc! {"
+                        GUID HOB
+                          HOB Length: 0x{:x}\n"},
+            hob.header.length
+          )?;
+        }
+        Hob::FirmwareVolume2(hob) => {
+          write!(
+            f,
+            indoc! {"
+                        FIRMWARE VOLUME 2 (FV2) HOB
+                          Base Address: 0x{:x}
+                          Length: 0x{:x}\n"},
+            hob.base_address, hob.length
+          )?;
+        }
+        Hob::FirmwareVolume3(hob) => {
+          write!(
+            f,
+            indoc! {"
+                        FIRMWARE VOLUME 3 (FV3) HOB
+                          Base Address: 0x{:x}
+                          Length: 0x{:x}\n"},
+            hob.base_address, hob.length
+          )?;
+        }
+        Hob::Cpu(hob) => {
+          write!(
+            f,
+            indoc! {"
+                        CPU HOB
+                          Memory Space Size: 0x{:x}
+                          IO Space Size: 0x{:x}\n"},
+            hob.size_of_memory_space, hob.size_of_io_space
+          )?;
+        }
+        Hob::Capsule(hob) => {
+          write!(
+            f,
+            indoc! {"
+                        CAPSULE HOB
+                          Base Address: 0x{:x}
+                          Length: 0x{:x}\n"},
+            hob.base_address, hob.length
+          )?;
+        }
+        _ => (),
+      }
+    }
+    write!(f, "Parsed HOBs")
+  }
+}
+
+impl Hob<'_> {
+  pub fn header(&self) -> header::Hob {
+    match self {
+      Hob::Handoff(hob) => hob.header,
+      Hob::MemoryAllocation(hob) => hob.header,
+      Hob::MemoryAllocationModule(hob) => hob.header,
+      Hob::Capsule(hob) => hob.header,
+      Hob::ResourceDescriptor(hob) => hob.header,
+      Hob::GuidHob(hob) => hob.header,
+      Hob::FirmwareVolume(hob) => hob.header,
+      Hob::FirmwareVolume2(hob) => hob.header,
+      Hob::FirmwareVolume3(hob) => hob.header,
+      Hob::Cpu(hob) => hob.header,
+      Hob::Misc(hob_type) => {
+        header::Hob { r#type: *hob_type, length: mem::size_of::<header::Hob>() as u16, reserved: 0 }
+      }
+    }
+  }
+}
+
+/// A HOB iterator.
+///
+pub struct HobIter<'a> {
+  hob_ptr: *const header::Hob,
+  _a: PhantomData<&'a ()>,
+}
+
+impl<'a> IntoIterator for &Hob<'a> {
+  type Item = Hob<'a>;
+
+  type IntoIter = HobIter<'a>;
+
+  fn into_iter(self) -> Self::IntoIter {
+    HobIter { hob_ptr: self.as_ptr(), _a: PhantomData }
+  }
+}
+
+impl<'a> Iterator for HobIter<'a> {
+  type Item = Hob<'a>;
+
+  fn next(&mut self) -> Option<Self::Item> {
+    const NOT_NULL: &str = "Ptr should not be NULL";
+    let hob_header = unsafe { *(self.hob_ptr) };
+    let hob = unsafe {
+      match hob_header.r#type {
+        HANDOFF => Hob::Handoff((self.hob_ptr as *const PhaseHandoffInformationTable).as_ref().expect(NOT_NULL)),
+        MEMORY_ALLOCATION if hob_header.length as usize == mem::size_of::<MemoryAllocationModule>() => {
+          Hob::MemoryAllocationModule((self.hob_ptr as *const MemoryAllocationModule).as_ref().expect(NOT_NULL))
+        }
+        MEMORY_ALLOCATION => Hob::MemoryAllocation((self.hob_ptr as *const MemoryAllocation).as_ref().expect(NOT_NULL)),
+        RESOURCE_DESCRIPTOR => {
+          Hob::ResourceDescriptor((self.hob_ptr as *const ResourceDescriptor).as_ref().expect(NOT_NULL))
+        }
+        GUID_EXTENSION => Hob::GuidHob((self.hob_ptr as *const GuidHob).as_ref().expect(NOT_NULL)),
+        FV => Hob::FirmwareVolume((self.hob_ptr as *const FirmwareVolume).as_ref().expect(NOT_NULL)),
+        FV2 => Hob::FirmwareVolume2((self.hob_ptr as *const FirmwareVolume2).as_ref().expect(NOT_NULL)),
+        FV3 => Hob::FirmwareVolume3((self.hob_ptr as *const FirmwareVolume3).as_ref().expect(NOT_NULL)),
+        CPU => Hob::Cpu((self.hob_ptr as *const Cpu).as_ref().expect(NOT_NULL)),
+        UEFI_CAPSULE => Hob::Capsule((self.hob_ptr as *const Capsule).as_ref().expect(NOT_NULL)),
+        END_OF_HOB_LIST => return None,
+        hob_type => Hob::Misc(hob_type),
+      }
+    };
+    self.hob_ptr = (self.hob_ptr as usize + hob_header.length as usize) as *const header::Hob;
+    Some(hob)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::{hob, hob::Hob, hob::HobList, hob::HobTrait};
+
+  use core::{
+    ffi::c_void,
+    mem::{drop, forget, size_of},
+    slice::from_raw_parts,
+  };
+
+  // Expectation is someone will provide alloc
+  extern crate alloc;
+  use alloc::vec::Vec;
+
+  // Generate a test firmware volume hob
+  // # Returns
+  // A FirmwareVolume hob
+  fn gen_firmware_volume() -> hob::FirmwareVolume {
+    let header = hob::header::Hob { r#type: hob::FV, length: size_of::<hob::FirmwareVolume>() as u16, reserved: 0 };
+
+    hob::FirmwareVolume { header, base_address: 0, length: 0x0123456789abcdef }
+  }
+
+  // Generate a test firmware volume 2 hob
+  // # Returns
+  // A FirmwareVolume2 hob
+  fn gen_firmware_volume2() -> hob::FirmwareVolume2 {
+    let header = hob::header::Hob { r#type: hob::FV2, length: size_of::<hob::FirmwareVolume2>() as u16, reserved: 0 };
+
+    hob::FirmwareVolume2 {
+      header,
+      base_address: 0,
+      length: 0x0123456789abcdef,
+      fv_name: r_efi::efi::Guid::from_fields(1, 2, 3, 4, 5, &[6, 7, 8, 9, 10, 11]),
+      file_name: r_efi::efi::Guid::from_fields(1, 2, 3, 4, 5, &[6, 7, 8, 9, 10, 11]),
+    }
+  }
+
+  // Generate a test firmware volume 3 hob
+  // # Returns
+  // A FirmwareVolume3 hob
+  fn gen_firmware_volume3() -> hob::FirmwareVolume3 {
+    let header = hob::header::Hob { r#type: hob::FV3, length: size_of::<hob::FirmwareVolume3>() as u16, reserved: 0 };
+
+    hob::FirmwareVolume3 {
+      header,
+      base_address: 0,
+      length: 0x0123456789abcdef,
+      authentication_status: 0,
+      extracted_fv: false.into(),
+      fv_name: r_efi::efi::Guid::from_fields(1, 2, 3, 4, 5, &[6, 7, 8, 9, 10, 11]),
+      file_name: r_efi::efi::Guid::from_fields(1, 2, 3, 4, 5, &[6, 7, 8, 9, 10, 11]),
+    }
+  }
+
+  // Generate a test resource descriptor hob
+  // # Returns
+  // A ResourceDescriptor hob
+  fn gen_resource_descriptor() -> hob::ResourceDescriptor {
+    let header = hob::header::Hob {
+      r#type: hob::RESOURCE_DESCRIPTOR,
+      length: size_of::<hob::ResourceDescriptor>() as u16,
+      reserved: 0,
+    };
+
+    hob::ResourceDescriptor {
+      header,
+      owner: r_efi::efi::Guid::from_fields(1, 2, 3, 4, 5, &[6, 7, 8, 9, 10, 11]),
+      resource_type: hob::EFI_RESOURCE_SYSTEM_MEMORY,
+      resource_attribute: hob::EFI_RESOURCE_ATTRIBUTE_PRESENT,
+      physical_start: 0,
+      resource_length: 0x0123456789abcdef,
+    }
+  }
+
+  // Generate a test phase handoff information table hob
+  // # Returns
+  // A MemoryAllocation hob
+  fn gen_memory_allocation() -> hob::MemoryAllocation {
+    let header = hob::header::Hob {
+      r#type: hob::MEMORY_ALLOCATION,
+      length: size_of::<hob::MemoryAllocation>() as u16,
+      reserved: 0,
+    };
+
+    let alloc_descriptor = hob::header::MemoryAllocation {
+      name: r_efi::efi::Guid::from_fields(1, 2, 3, 4, 5, &[6, 7, 8, 9, 10, 11]),
+      memory_base_address: 0,
+      memory_length: 0x0123456789abcdef,
+      memory_type: 0,
+      reserved: [0; 4],
+    };
+
+    hob::MemoryAllocation { header, alloc_descriptor }
+  }
+
+  fn gen_memory_allocation_module() -> hob::MemoryAllocationModule {
+    let header = hob::header::Hob {
+      r#type: hob::MEMORY_ALLOCATION,
+      length: size_of::<hob::MemoryAllocationModule>() as u16,
+      reserved: 0,
+    };
+
+    let alloc_descriptor = hob::header::MemoryAllocation {
+      name: r_efi::efi::Guid::from_fields(1, 2, 3, 4, 5, &[6, 7, 8, 9, 10, 11]),
+      memory_base_address: 0,
+      memory_length: 0x0123456789abcdef,
+      memory_type: 0,
+      reserved: [0; 4],
+    };
+
+    hob::MemoryAllocationModule {
+      header,
+      alloc_descriptor,
+      module_name: r_efi::efi::Guid::from_fields(1, 2, 3, 4, 5, &[6, 7, 8, 9, 10, 11]),
+      entry_point: 0,
+    }
+  }
+
+  fn gen_capsule() -> hob::Capsule {
+    let header = hob::header::Hob { r#type: hob::UEFI_CAPSULE, length: size_of::<hob::Capsule>() as u16, reserved: 0 };
+
+    hob::Capsule { header, base_address: 0, length: 0x12 }
+  }
+
+  fn gen_guid_hob() -> hob::GuidHob {
+    let header =
+      hob::header::Hob { r#type: hob::GUID_EXTENSION, length: size_of::<hob::GuidHob>() as u16, reserved: 0 };
+
+    hob::GuidHob { header, name: r_efi::efi::Guid::from_fields(1, 2, 3, 4, 5, &[6, 7, 8, 9, 10, 11]) }
+  }
+
+  fn gen_phase_handoff_information_table() -> hob::PhaseHandoffInformationTable {
+    let header = hob::header::Hob {
+      r#type: hob::HANDOFF,
+      length: size_of::<hob::PhaseHandoffInformationTable>() as u16,
+      reserved: 0,
+    };
+
+    hob::PhaseHandoffInformationTable {
+      header,
+      version: 0x00010000,
+      boot_mode: 0,
+      memory_top: 0xdeadbeef,
+      memory_bottom: 0xdeadc0de,
+      free_memory_top: 104,
+      free_memory_bottom: 255,
+      end_of_hob_list: 0xdeaddeadc0dec0de,
+    }
+  }
+
+  // Generate a test end of hoblist hob
+  // # Returns
+  // A PhaseHandoffInformationTable hob
+  fn gen_end_of_hoblist() -> hob::PhaseHandoffInformationTable {
+    let header = hob::header::Hob {
+      r#type: hob::END_OF_HOB_LIST,
+      length: size_of::<hob::PhaseHandoffInformationTable>() as u16,
+      reserved: 0,
+    };
+
+    hob::PhaseHandoffInformationTable {
+      header,
+      version: 0x00010000,
+      boot_mode: 0,
+      memory_top: 0xdeadbeef,
+      memory_bottom: 0xdeadc0de,
+      free_memory_top: 104,
+      free_memory_bottom: 255,
+      end_of_hob_list: 0xdeaddeadc0dec0de,
+    }
+  }
+
+  fn gen_cpu() -> hob::Cpu {
+    let header = hob::header::Hob { r#type: hob::CPU, length: size_of::<hob::Cpu>() as u16, reserved: 0 };
+
+    hob::Cpu { header, size_of_memory_space: 0, size_of_io_space: 0, reserved: [0; 6] }
+  }
+
+  // Converts the Hoblist to a C array.
+  // # Arguments
+  // * `hob_list` - A reference to the HobList.
+  //
+  // # Returns
+  // A tuple containing a pointer to the C array and the length of the C array.
+  pub fn to_c_array(hob_list: &hob::HobList) -> (*const c_void, usize) {
+    let size = hob_list.size();
+    let mut c_array: Vec<u8> = Vec::with_capacity(size);
+
+    for hob in hob_list.iter() {
+      let slice = unsafe { from_raw_parts(hob.as_ptr(), hob.size()) };
+      c_array.extend_from_slice(slice);
+    }
+
+    let void_ptr = c_array.as_ptr() as *const c_void;
+
+    // in order to not call the destructor on the Vec at the end of this function, we need to forget it
+    forget(c_array);
+
+    (void_ptr, size)
+  }
+
+  // Implements a function to manually free a C array.
+  //
+  // # Arguments
+  // * `c_array_ptr` - A pointer to the C array.
+  // * `len` - The length of the C array.
+  //
+  // # Safety
+  // This function is unsafe because it is not guaranteed that the pointer is valid.
+  pub fn manually_free_c_array(c_array_ptr: *const c_void, len: usize) {
+    let ptr = c_array_ptr as *mut u8;
+    unsafe {
+      drop(Vec::from_raw_parts(ptr, len, len));
+    }
+  }
+
+  #[test]
+  fn test_hoblist_empty() {
+    let hoblist = HobList::new();
+    assert_eq!(hoblist.len(), 0);
+    assert!(hoblist.is_empty());
+  }
+
+  #[test]
+  fn test_hoblist_push() {
+    let mut hoblist = HobList::new();
+    let resource = gen_resource_descriptor();
+    hoblist.push(Hob::ResourceDescriptor(&resource));
+    assert_eq!(hoblist.len(), 1);
+
+    let firmware_volume = gen_firmware_volume();
+    hoblist.push(Hob::FirmwareVolume(&firmware_volume));
+
+    assert_eq!(hoblist.len(), 2);
+  }
+
+  #[test]
+  fn test_hoblist_iterate() {
+    let mut hoblist = HobList::default();
+    let resource = gen_resource_descriptor();
+    let firmware_volume = gen_firmware_volume();
+    let firmware_volume2 = gen_firmware_volume2();
+    let firmware_volume3 = gen_firmware_volume3();
+    let end_of_hob_list = gen_end_of_hoblist();
+    let capsule = gen_capsule();
+    let guid_hob = gen_guid_hob();
+    let memory_allocation = gen_memory_allocation();
+    let memory_allocation_module = gen_memory_allocation_module();
+
+    hoblist.push(Hob::ResourceDescriptor(&resource));
+    hoblist.push(Hob::FirmwareVolume(&firmware_volume));
+    hoblist.push(Hob::FirmwareVolume2(&firmware_volume2));
+    hoblist.push(Hob::FirmwareVolume3(&firmware_volume3));
+    hoblist.push(Hob::Capsule(&capsule));
+    hoblist.push(Hob::GuidHob(&guid_hob));
+    hoblist.push(Hob::MemoryAllocation(&memory_allocation));
+    hoblist.push(Hob::MemoryAllocationModule(&memory_allocation_module));
+    hoblist.push(Hob::Handoff(&end_of_hob_list));
+
+    let mut count = 0;
+    hoblist.iter().for_each(|hob| {
+      match hob {
+        Hob::ResourceDescriptor(resource) => {
+          assert_eq!(resource.resource_type, hob::EFI_RESOURCE_SYSTEM_MEMORY);
+        }
+        Hob::MemoryAllocation(memory_allocation) => {
+          assert_eq!(memory_allocation.alloc_descriptor.memory_length, 0x0123456789abcdef);
+        }
+        Hob::MemoryAllocationModule(memory_allocation_module) => {
+          assert_eq!(memory_allocation_module.alloc_descriptor.memory_length, 0x0123456789abcdef);
+        }
+        Hob::Capsule(capsule) => {
+          assert_eq!(capsule.base_address, 0);
+        }
+        Hob::GuidHob(guid_hob) => {
+          assert_eq!(guid_hob.name, r_efi::efi::Guid::from_fields(1, 2, 3, 4, 5, &[6, 7, 8, 9, 10, 11]));
+        }
+        Hob::FirmwareVolume(firmware_volume) => {
+          assert_eq!(firmware_volume.length, 0x0123456789abcdef);
+        }
+        Hob::FirmwareVolume2(firmware_volume) => {
+          assert_eq!(firmware_volume.length, 0x0123456789abcdef);
+        }
+        Hob::FirmwareVolume3(firmware_volume) => {
+          assert_eq!(firmware_volume.length, 0x0123456789abcdef);
+        }
+        Hob::Handoff(handoff) => {
+          assert_eq!(handoff.memory_top, 0xdeadbeef);
+        }
+        _ => {
+          panic!("Unexpected hob type");
+        }
+      }
+      count += 1;
+    });
+    assert_eq!(count, 9);
+  }
+
+  #[test]
+  fn test_hoblist_discover() {
+    // generate some test hobs
+    let resource = gen_resource_descriptor();
+    let handoff = gen_phase_handoff_information_table();
+    let firmware_volume = gen_firmware_volume();
+    let firmware_volume2 = gen_firmware_volume2();
+    let firmware_volume3 = gen_firmware_volume3();
+    let capsule = gen_capsule();
+    let guid_hob = gen_guid_hob();
+    let memory_allocation = gen_memory_allocation();
+    let memory_allocation_module = gen_memory_allocation_module();
+    let cpu = gen_cpu();
+    let end_of_hob_list = gen_end_of_hoblist();
+
+    // create a new hoblist
+    let mut hoblist = HobList::new();
+
+    // Push the resource descriptor to the hoblist
+    hoblist.push(Hob::ResourceDescriptor(&resource));
+    hoblist.push(Hob::Handoff(&handoff));
+    hoblist.push(Hob::FirmwareVolume(&firmware_volume));
+    hoblist.push(Hob::FirmwareVolume2(&firmware_volume2));
+    hoblist.push(Hob::FirmwareVolume3(&firmware_volume3));
+    hoblist.push(Hob::Capsule(&capsule));
+    hoblist.push(Hob::GuidHob(&guid_hob));
+    hoblist.push(Hob::MemoryAllocation(&memory_allocation));
+    hoblist.push(Hob::MemoryAllocationModule(&memory_allocation_module));
+    hoblist.push(Hob::Cpu(&cpu));
+    hoblist.push(Hob::Handoff(&end_of_hob_list));
+
+    // assert that the hoblist has 3 hobs and they are of the correct type
+
+    let mut count = 0;
+    hoblist.iter().for_each(|hob| {
+      match hob {
+        Hob::ResourceDescriptor(resource) => {
+          assert_eq!(resource.resource_type, hob::EFI_RESOURCE_SYSTEM_MEMORY);
+        }
+        Hob::MemoryAllocation(memory_allocation) => {
+          assert_eq!(memory_allocation.alloc_descriptor.memory_length, 0x0123456789abcdef);
+        }
+        Hob::MemoryAllocationModule(memory_allocation_module) => {
+          assert_eq!(memory_allocation_module.alloc_descriptor.memory_length, 0x0123456789abcdef);
+        }
+        Hob::Capsule(capsule) => {
+          assert_eq!(capsule.base_address, 0);
+        }
+        Hob::GuidHob(guid_hob) => {
+          assert_eq!(guid_hob.name, r_efi::efi::Guid::from_fields(1, 2, 3, 4, 5, &[6, 7, 8, 9, 10, 11]));
+        }
+        Hob::FirmwareVolume(firmware_volume) => {
+          assert_eq!(firmware_volume.length, 0x0123456789abcdef);
+        }
+        Hob::FirmwareVolume2(firmware_volume) => {
+          assert_eq!(firmware_volume.length, 0x0123456789abcdef);
+        }
+        Hob::FirmwareVolume3(firmware_volume) => {
+          assert_eq!(firmware_volume.length, 0x0123456789abcdef);
+        }
+        Hob::Handoff(handoff) => {
+          assert_eq!(handoff.memory_top, 0xdeadbeef);
+        }
+        Hob::Cpu(cpu) => {
+          assert_eq!(cpu.size_of_memory_space, 0);
+        }
+        _ => {
+          panic!("Unexpected hob type");
+        }
+      }
+      count += 1;
+    });
+
+    assert_eq!(count, 11);
+
+    // c_hoblist is a pointer to the hoblist - we need to manually free it later
+    let (c_array_hoblist, length) = to_c_array(&hoblist);
+
+    // create a new hoblist
+    let mut cloned_hoblist = HobList::new();
+    cloned_hoblist.discover_hobs(c_array_hoblist);
+
+    // assert that the hoblist has 2 hobs and they are of the correct type
+    // we don't need to check the end of hoblist hob as it will not be 'discovered'
+    // by the discover_hobs function and simply end the iteration
+    count = 0;
+    hoblist.into_iter().for_each(|hob| {
+      match hob {
+        Hob::ResourceDescriptor(resource) => {
+          assert_eq!(resource.resource_type, hob::EFI_RESOURCE_SYSTEM_MEMORY);
+        }
+        Hob::MemoryAllocation(memory_allocation) => {
+          assert_eq!(memory_allocation.alloc_descriptor.memory_length, 0x0123456789abcdef);
+        }
+        Hob::MemoryAllocationModule(memory_allocation_module) => {
+          assert_eq!(memory_allocation_module.alloc_descriptor.memory_length, 0x0123456789abcdef);
+        }
+        Hob::Capsule(capsule) => {
+          assert_eq!(capsule.base_address, 0);
+        }
+        Hob::GuidHob(guid_hob) => {
+          assert_eq!(guid_hob.name, r_efi::efi::Guid::from_fields(1, 2, 3, 4, 5, &[6, 7, 8, 9, 10, 11]));
+        }
+        Hob::FirmwareVolume(firmware_volume) => {
+          assert_eq!(firmware_volume.length, 0x0123456789abcdef);
+        }
+        Hob::FirmwareVolume2(firmware_volume) => {
+          assert_eq!(firmware_volume.length, 0x0123456789abcdef);
+        }
+        Hob::FirmwareVolume3(firmware_volume) => {
+          assert_eq!(firmware_volume.length, 0x0123456789abcdef);
+        }
+        Hob::Handoff(handoff) => {
+          assert_eq!(handoff.memory_top, 0xdeadbeef);
+        }
+        Hob::Cpu(cpu) => {
+          assert_eq!(cpu.size_of_memory_space, 0);
+        }
+        _ => {
+          panic!("Unexpected hob type");
+        }
+      }
+      count += 1;
+    });
+
+    assert_eq!(count, 11);
+
+    // free the c array
+    manually_free_c_array(c_array_hoblist, length);
+  }
+
+  #[test]
+  fn test_hob_iterator() {
+    // generate some test hobs
+    let resource = gen_resource_descriptor();
+    let handoff = gen_phase_handoff_information_table();
+    let firmware_volume = gen_firmware_volume();
+    let firmware_volume2 = gen_firmware_volume2();
+    let firmware_volume3 = gen_firmware_volume3();
+    let capsule = gen_capsule();
+    let guid_hob = gen_guid_hob();
+    let memory_allocation = gen_memory_allocation();
+    let memory_allocation_module = gen_memory_allocation_module();
+    let cpu = gen_cpu();
+    let end_of_hob_list = gen_end_of_hoblist();
+
+    // create a new hoblist
+    let mut hoblist = HobList::new();
+
+    // Push the resource descriptor to the hoblist
+    hoblist.push(Hob::ResourceDescriptor(&resource));
+    hoblist.push(Hob::Handoff(&handoff));
+    hoblist.push(Hob::FirmwareVolume(&firmware_volume));
+    hoblist.push(Hob::FirmwareVolume2(&firmware_volume2));
+    hoblist.push(Hob::FirmwareVolume3(&firmware_volume3));
+    hoblist.push(Hob::Capsule(&capsule));
+    hoblist.push(Hob::GuidHob(&guid_hob));
+    hoblist.push(Hob::MemoryAllocation(&memory_allocation));
+    hoblist.push(Hob::MemoryAllocationModule(&memory_allocation_module));
+    hoblist.push(Hob::Cpu(&cpu));
+    hoblist.push(Hob::Handoff(&end_of_hob_list));
+
+    let (c_array_hoblist, length) = to_c_array(&hoblist);
+
+    let hob = Hob::ResourceDescriptor(unsafe {
+      (c_array_hoblist as *const hob::ResourceDescriptor).as_ref::<'static>().unwrap()
+    });
+    for h in &hob {
+      println!("{:?}", h.header());
+    }
+
+    manually_free_c_array(c_array_hoblist, length);
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,38 @@
+//! Platform Initialization (PI) Specification Definitions and Support Code
+//!
+//! This crate provides constants, definitions, and support code for the Platform Initialization (PI) Specification
+//! maintained by the UEFI Forum. The primary focus is to provide rust types and constants to build a PI Specification
+//! compliant firmware, functionality is allowed to be implemented around those types as well. Code implementation
+//! must be applicable to any PI spec compliant firmware that may need the associated functionality.
+//!
+//! Refer to the Platform Initialization (PI) Specification for more background on the specification.
+//! <https://uefi.org/specs/PI/1.8A/>
+//!
+//! # UEFI Environment
+//!
+//! This crate depends on the r-efi crate for UEFI defined constants and definitions defined in the UEFI Specification.
+//! That project contains important details about writing Rust code agains the UEFI Specification. Those details are
+//! not repeated here. Read that project's documentation when setting up a UEFI project.
+//!
+//! # Current State
+//!
+//! The PI Specification describes a number of boot phases and concepts used across those boot phases referred to as
+//! "Shared Architectural Elements". The implementation predominantly focuses on the DXE phase at this time. This
+//! includes shared elements used in other stages such as the HOBs and firmware storage. Contributions to expand
+//! coverage of the specification are welcome.
+//!
+//! The overall structure and design of the crate is subject to breaking changes at this time. The code is being
+//! shared for wider feedback and collaboration that might result in fundamental changes to the organization of
+//! content. These details will be documented and managed using appropriately versioned releases of the crate to
+//! reflect the degree of change.
+//!
+
+#![cfg_attr(not(test), no_std)]
+#![cfg_attr(feature = "nightly", feature(coverage_attribute))]
+
+mod address_helper;
+pub mod dxe_services;
+pub mod fw_fs;
+pub mod hob;
+pub mod list_entry;
+pub mod protocols;

--- a/src/list_entry.rs
+++ b/src/list_entry.rs
@@ -1,0 +1,22 @@
+//! Linked List Entry
+//!
+//! Defined in the PI Specification as an EFI Linked List entry (EfiListEntry). See Related Definitions for the
+//! Runtime Architectural Protocol.
+//!
+//! Represents a doubly linked list where with forward and back links.
+//!
+//! See <https://uefi.org/specs/PI/1.8A/V2_DXE_Architectural_Protocols.html#efi-runtime-arch-protocol>.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct Entry {
+  pub forward_link: *mut Entry,
+  pub back_link: *mut Entry,
+}

--- a/src/protocols.rs
+++ b/src/protocols.rs
@@ -1,0 +1,20 @@
+//! Platform Initialization Protocols
+//!
+//! Each protocol in the PI Specification is maintained as a separate module.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+pub mod bds;
+pub mod cpu_arch;
+pub mod firmware_volume;
+pub mod firmware_volume_block;
+pub mod metronome;
+pub mod runtime;
+pub mod status_code;
+pub mod timer;
+pub mod watchdog;

--- a/src/protocols/bds.rs
+++ b/src/protocols/bds.rs
@@ -1,0 +1,36 @@
+//! Boot Device Selection (BDS) Architectural Protocol
+//!
+//! Transfers control from the DXE phase to an operating system or system utility.
+//!
+//! See <https://uefi.org/specs/PI/1.8A/V2_DXE_Architectural_Protocols.html#boot-device-selection-bds-architectural-protocol>
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+use r_efi::efi;
+
+/// BDS Architectural Protocol GUID
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.2.1
+pub const PROTOCOL_GUID: efi::Guid =
+  efi::Guid::from_fields(0x665E3FF6, 0x46CC, 0x11d4, 0x9A, 0x38, &[0x00, 0x90, 0x27, 0x3F, 0xC1, 0x4D]);
+
+/// Performs Boot Device Selection (BDS) and transfers control from the DXE Foundation to the selected boot device.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.2.2
+pub type BdsEntry = extern "efiapi" fn(*mut Protocol);
+
+/// Transfers control from the DXE phase to an operating system or system utility.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.2.1
+#[repr(C)]
+pub struct Protocol {
+  pub entry: BdsEntry,
+}

--- a/src/protocols/cpu_arch.rs
+++ b/src/protocols/cpu_arch.rs
@@ -1,0 +1,128 @@
+//! CPU Architectural Protocol
+//!
+//! Abstracts the processor services that are required to implement some of the DXE services.
+//!
+//! See <https://uefi.org/specs/PI/1.8A/V2_DXE_Architectural_Protocols.html#cpu-architectural-protocol>
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+use core::ffi::c_void;
+
+use r_efi::efi;
+
+/// CPU Architectrural Protocol GUID
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.3.1
+pub const PROTOCOL_GUID: efi::Guid =
+  efi::Guid::from_fields(0x26baccb1, 0x6f42, 0x11d4, 0xbc, 0xe7, &[0x00, 0x80, 0xc7, 0x3c, 0x88, 0x81]);
+
+#[repr(C)]
+pub enum CpuFlushType {
+  EfiCpuFlushTypeWriteBackInvalidate,
+  EfiCpuFlushTypeWriteBack,
+  EFiCpuFlushTypeInvalidate,
+}
+
+/// Flushes a range of the processor's data cache.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.3.2
+pub type FlushDataCache = extern "efiapi" fn(*const Protocol, efi::PhysicalAddress, u64, CpuFlushType) -> efi::Status;
+
+/// Enables interrupt processing by the processor.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.3.3
+pub type EnableInterrupt = extern "efiapi" fn(*const Protocol) -> efi::Status;
+
+/// Disables interrupt processing by the processor.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.3.4
+pub type DisableInterrupt = extern "efiapi" fn(*const Protocol) -> efi::Status;
+
+/// Retrieves the processor's current interrupt state.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.3.5
+pub type GetInterruptState = extern "efiapi" fn(*const Protocol, *mut bool) -> efi::Status;
+
+#[repr(C)]
+pub enum CpuInitType {
+  EfiCpuInit,
+}
+
+/// Generates an INIT on the processor.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.3.6
+pub type Init = extern "efiapi" fn(*const Protocol, CpuInitType) -> efi::Status;
+
+/// Specifies which processor exception to hook.
+///
+/// # Documentation
+/// UEFI Specification version 2.10, Section 18.2.5
+pub type EfiExceptionType = isize;
+
+/// Pointer to system context structure.
+///
+/// # Documentation
+/// UEFI Specification version 2.10, Section 18.2.4
+pub type EfiSystemContext = *mut c_void;
+
+/// Function type definition for interrupt handler.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.3.7
+pub type InterruptHandler = extern "efiapi" fn(EfiExceptionType, EfiSystemContext);
+
+/// Registers a function to be called from the processor interrupt handler.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.3.7
+pub type RegisterInterruptHandler =
+  extern "efiapi" fn(*const Protocol, EfiExceptionType, InterruptHandler) -> efi::Status;
+
+/// Returns a timer value from one of the processor's internal timers.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.3.8
+pub type GetTimerValue = extern "efiapi" fn(*const Protocol, u32, *mut u64, *mut u64) -> efi::Status;
+
+/// Change a memory region to support specified memory attributes.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.3.9
+pub type SetMemoryAttributes = extern "efiapi" fn(*const Protocol, efi::PhysicalAddress, u64, u64) -> efi::Status;
+
+/// Abstracts the processor services that are required to implement some of the DXE services.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.3.1
+#[repr(C)]
+pub struct Protocol {
+  pub flush_data_cache: FlushDataCache,
+  pub enable_interrupt: EnableInterrupt,
+  pub disable_interrupt: DisableInterrupt,
+  pub get_interrupt_state: GetInterruptState,
+  pub init: Init,
+  pub register_interrupt_handler: RegisterInterruptHandler,
+  pub get_timer_value: GetTimerValue,
+  pub set_memory_attributes: SetMemoryAttributes,
+  /// The number of timers that are available in a processor. The value in this field is a constant that must not be
+  /// modified after the CPU Architectural Protocol is installed. All consumers must treat this as a read-only field.
+  pub number_of_timers: u32,
+  /// The size, in bytes, of the alignment required for DMA buffer allocations. This is typically the size of the
+  /// largest data cache line in the platform. This value can be determined by looking at the data cache line sizes of
+  /// all the caches present in the platform, and returning the largest. This is used by the root bridge I/O abstraction
+  /// protocols to guarantee that no two DMA buffers ever share the same cache line. The value in this field is a
+  /// constant that must not be modified after the CPU Architectural Protocol is installed. All consumers must treat
+  /// this as a read-only field.
+  pub dma_buffer_alignment: u32,
+}

--- a/src/protocols/firmware_volume.rs
+++ b/src/protocols/firmware_volume.rs
@@ -1,0 +1,99 @@
+//! Firmware Volume (FV) Protocol
+//!
+//! The Firmware Volume Protocol provides file-level access to the firmware volume. Each firmware volume driver must
+//! produce an instance of the Firmware Volume Protocol if the firmware volume is to be visible to the system during
+//! the DXE phase. The Firmware Volume Protocol also provides mechanisms for determining and modifying some attributes
+//! of the firmware volume.
+//!
+//! See <https://uefi.org/specs/PI/1.8A/V3_Code_Definitions.html#efi-firmware-volume2-protocol>.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+use crate::fw_fs;
+
+use fw_fs::{
+  ffs::section::EfiSectionType,
+  fv::{attributes::EfiFvAttributes, file::EfiFvFileAttributes, EfiFvFileType},
+};
+
+use core::ffi::c_void;
+use r_efi::efi::{Guid, Handle, Status};
+
+pub const PROTOCOL_GUID: Guid =
+  Guid::from_fields(0x220e73b6, 0x6bdb, 0x4413, 0x84, 0x5, &[0xb9, 0x74, 0xb1, 0x8, 0x61, 0x9a]);
+
+pub type EfiFvWritePolicy = u32;
+
+#[repr(C)]
+pub struct EfiFvWriteFileData {
+  name_guid: *mut Guid,
+  file_type: EfiFvFileType,
+  file_attributes: EfiFvFileAttributes,
+  buffer: *mut c_void,
+  buffer_size: u32,
+}
+
+pub type GetVolumeAttributes = extern "efiapi" fn(*const Protocol, *mut EfiFvAttributes) -> Status;
+
+pub type SetVolumeAttributes = extern "efiapi" fn(*const Protocol, *mut EfiFvAttributes) -> Status;
+
+pub type ReadFile = extern "efiapi" fn(
+  *const Protocol,
+  *const Guid,
+  *mut *mut c_void,
+  *mut usize,
+  *mut EfiFvFileType,
+  *mut EfiFvFileAttributes,
+  *mut u32,
+) -> Status;
+
+pub type ReadSection = extern "efiapi" fn(
+  *const Protocol,
+  *const Guid,
+  EfiSectionType,
+  usize,
+  *mut *mut c_void,
+  *mut usize,
+  *mut u32,
+) -> Status;
+
+pub type WriteFile = extern "efiapi" fn(*const Protocol, u32, EfiFvWritePolicy, *mut EfiFvWriteFileData) -> Status;
+
+pub type GetNextFile = extern "efiapi" fn(
+  *const Protocol,
+  *mut c_void,
+  *mut EfiFvFileType,
+  *mut Guid,
+  *mut EfiFvFileAttributes,
+  *mut usize,
+) -> Status;
+
+pub type GetInfo = extern "efiapi" fn(*const Protocol, *const Guid, *mut usize, *mut c_void) -> Status;
+
+pub type SetInfo = extern "efiapi" fn(*const Protocol, *const Guid, usize, *const c_void) -> Status;
+
+/// The Firmware Volume Protocol provides file-level access to the firmware volume. Each firmware volume driver must
+/// produce an instance of the Firmware Volume Protocol if the firmware volume is to be visible to the system during
+/// the DXE phase. The Firmware Volume Protocol also provides mechanisms for determining and modifying some attributes
+/// of the firmware volume.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section III-3.4.1.1
+#[repr(C)]
+pub struct Protocol {
+  pub get_volume_attributes: GetVolumeAttributes,
+  pub set_volume_attributes: SetVolumeAttributes,
+  pub read_file: ReadFile,
+  pub read_section: ReadSection,
+  pub write_file: WriteFile,
+  pub get_next_file: GetNextFile,
+  pub key_size: u32,
+  pub parent_handle: Handle,
+  pub get_info: GetInfo,
+  pub set_info: SetInfo,
+}

--- a/src/protocols/firmware_volume_block.rs
+++ b/src/protocols/firmware_volume_block.rs
@@ -1,0 +1,57 @@
+//! Firmware Volume Block (FVB) Protocol
+//!
+//! The Firmware Volume Block Protocol is the low-level interface to a firmware volume. File-level access to a firmware
+//! volume should not be done using thE Firmware Volume Block Protocol. Normal access to a firmware volume must use
+//! the Firmware Volume Protocol.
+//!
+//! See <https://uefi.org/specs/PI/1.8A/V3_Code_Definitions.html#efi-firmware-volume-block2-protocol>.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+use core::ffi::c_void;
+use r_efi::efi::{Guid, Handle, Lba, Status};
+
+use crate::{fw_fs::EfiFvbAttributes2, hob::EfiPhysicalAddress};
+
+pub const PROTOCOL_GUID: Guid =
+  Guid::from_fields(0x8f644fa9, 0xe850, 0x4db1, 0x9c, 0xe2, &[0xb, 0x44, 0x69, 0x8e, 0x8d, 0xa4]);
+
+pub type GetAttributes = extern "efiapi" fn(*mut Protocol, *mut EfiFvbAttributes2) -> Status;
+
+pub type SetAttributes = extern "efiapi" fn(*mut Protocol, *mut EfiFvbAttributes2) -> Status;
+
+pub type GetPhysicalAddress = extern "efiapi" fn(*mut Protocol, *mut EfiPhysicalAddress) -> Status;
+
+pub type GetBlockSize = extern "efiapi" fn(*mut Protocol, Lba, *mut usize, *mut usize) -> Status;
+
+pub type Read = extern "efiapi" fn(*mut Protocol, Lba, usize, *mut usize, *mut c_void) -> Status;
+
+pub type Write = extern "efiapi" fn(*mut Protocol, Lba, usize, *mut usize, *mut c_void) -> Status;
+
+pub type EraseBlocks = extern "efiapi" fn(
+  *mut Protocol,
+  //... //TODO: variadic functions and eficall! do not mix presently.
+) -> Status;
+
+/// The Firmware Volume Block Protocol is the low-level interface to a firmware volume. File-level access to a firmware
+/// volume should not be done using thE Firmware Volume Block Protocol. Normal access to a firmware volume must use
+/// the Firmware Volume Protocol.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section III-3.4.2.1
+#[repr(C)]
+pub struct Protocol {
+  pub get_attributes: GetAttributes,
+  pub set_attributes: SetAttributes,
+  pub get_physical_address: GetPhysicalAddress,
+  pub get_block_size: GetBlockSize,
+  pub read: Read,
+  pub write: Write,
+  pub erase_blocks: EraseBlocks,
+  pub parent_handle: Handle,
+}

--- a/src/protocols/metronome.rs
+++ b/src/protocols/metronome.rs
@@ -1,0 +1,45 @@
+//! Metronome Architectural Protocol
+//!
+//! Used to wait for ticks from a known time source in a platform. This protocol may be used to implement a simple
+//! version of the Stall() Boot Service.
+//!
+//! See <https://uefi.org/specs/PI/1.8A/V2_DXE_Architectural_Protocols.html#metronome-architectural-protocol>
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+use r_efi::efi;
+
+/// Metronome Architectural Protocol GUID
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.4.1
+pub const PROTOCOL_GUID: efi::Guid =
+  efi::Guid::from_fields(0x26baccb2, 0x6f42, 0x11d4, 0xbc, 0xe7, &[0x00, 0x80, 0xc7, 0x3c, 0x88, 0x81]);
+
+/// Waits for a specified number of ticks from a known time source in a platform.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.4.2
+pub type WaitForTick = extern "efiapi" fn(*const Protocol, tick_number: u32) -> efi::Status;
+
+/// Used to wait for ticks from a known time source in a platform.
+///
+/// This protocol may be used to implement a simple version of the Stall() Boot Service. This protocol must be produced
+/// by a boot service or runtime DXE driver and may only be consumed by the DXE Foundation and DXE drivers that produce
+/// DXE Architectural Protocols.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.4.1
+#[repr(C)]
+pub struct Protocol {
+  pub wait_for_tick: WaitForTick,
+  /// The period of platform’s known time source in 100 ns units. This value on any platform must not exceed 200
+  /// microseconds. The value in this field is a constant that must not be modified after the Metronome architectural
+  /// protocol is installed. All consumers must treat this as a read-only field.
+  pub tick_period: u32,
+}

--- a/src/protocols/runtime.rs
+++ b/src/protocols/runtime.rs
@@ -1,0 +1,45 @@
+//! Runtime Architectural Protocol
+//!
+//! Contains the UEFI runtime services that are callable only in physical mode.
+//!
+//! See <https://uefi.org/specs/PI/1.8A/V2_DXE_Architectural_Protocols.html#runtime-architectural-protocol>
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+use core::sync::atomic::AtomicBool;
+
+use crate::list_entry;
+use r_efi::efi;
+
+pub const PROTOCOL_GUID: efi::Guid =
+  efi::Guid::from_fields(0xb7dfb4e1, 0x052f, 0x449f, 0x87, 0xbe, &[0x98, 0x18, 0xfc, 0x91, 0xb7, 0x33]);
+
+/// Allows the runtime functionality of the DXE Foundation to be contained
+/// in a separate driver. It also provides hooks for the DXE Foundation to
+/// export information that is needed at runtime. As such, this protocol allows
+/// services to the DXE Foundation to manage runtime drivers and events.
+/// This protocol also implies that the runtime services required to transition
+/// to virtual mode, SetVirtualAddressMap() and ConvertPointer(), have been
+/// registered into the UEFI Runtime Table in the UEFI System Table. This protocol
+/// must be produced by a runtime DXE driver and may only be consumed by the DXE Foundation.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.8.1
+#[repr(C)]
+#[derive(Debug)]
+pub struct Protocol {
+  pub image_head: list_entry::Entry,
+  pub event_head: list_entry::Entry,
+  pub memory_descriptor_size: usize,
+  pub memory_descriptor_version: u32,
+  pub memory_map_size: usize,
+  pub memory_map_physical: *mut efi::MemoryDescriptor,
+  pub memory_map_virtual: *mut efi::MemoryDescriptor,
+  pub virtual_mode: AtomicBool,
+  pub at_runtime: AtomicBool,
+}

--- a/src/protocols/status_code.rs
+++ b/src/protocols/status_code.rs
@@ -1,0 +1,151 @@
+//! Status Code Protocol
+//!
+//! Provides the service required to report a status code to the platform firmware.
+//!
+//! See <https://uefi.org/specs/PI/1.8A/V2_DXE_Runtime_Protocols.html#efi-status-code-protocol>
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+use r_efi::efi;
+
+pub const PROTOCOL_GUID: efi::Guid =
+  efi::Guid::from_fields(0xD2B2B828, 0x0826, 0x48A7, 0xB3, 0xDF, &[0x98, 0x3C, 0x00, 0x60, 0x24, 0xF0]);
+
+///
+/// Definition of code types. All other values masked by
+/// EFI_STATUS_CODE_TYPE_MASK are reserved for use by
+/// this specification.
+///
+pub const EFI_PROGRESS_CODE: u32 = 0x00000001;
+pub const EFI_ERROR_CODE: u32 = 0x00000002;
+pub const EFI_DEBUG_CODE: u32 = 0x00000003;
+
+///
+/// Class definitions.
+/// Values of 4-127 are reserved for future use by this specification.
+/// Values in the range 127-255 are reserved for OEM use.
+///
+pub const EFI_COMPUTING_UNIT: u32 = 0x00000000;
+pub const EFI_PERIPHERAL: u32 = 0x01000000;
+pub const EFI_IO_BUS: u32 = 0x02000000;
+pub const EFI_SOFTWARE: u32 = 0x03000000;
+
+///
+/// Software Subclass definitions.
+/// Values of 14-127 are reserved for future use by this specification.
+/// Values of 128-255 are reserved for OEM use.
+///
+pub const EFI_SOFTWARE_UNSPECIFIED: u32 = EFI_SOFTWARE;
+pub const EFI_SOFTWARE_SEC: u32 = EFI_SOFTWARE | 0x00010000;
+pub const EFI_SOFTWARE_PEI_CORE: u32 = EFI_SOFTWARE | 0x00020000;
+pub const EFI_SOFTWARE_PEI_MODULE: u32 = EFI_SOFTWARE | 0x00030000;
+pub const EFI_SOFTWARE_DXE_CORE: u32 = EFI_SOFTWARE | 0x00040000;
+pub const EFI_SOFTWARE_DXE_BS_DRIVER: u32 = EFI_SOFTWARE | 0x00050000;
+pub const EFI_SOFTWARE_DXE_RT_DRIVER: u32 = EFI_SOFTWARE | 0x00060000;
+pub const EFI_SOFTWARE_SMM_DRIVER: u32 = EFI_SOFTWARE | 0x00070000;
+pub const EFI_SOFTWARE_EFI_APPLICATION: u32 = EFI_SOFTWARE | 0x00080000;
+pub const EFI_SOFTWARE_EFI_OS_LOADER: u32 = EFI_SOFTWARE | 0x00090000;
+pub const EFI_SOFTWARE_RT: u32 = EFI_SOFTWARE | 0x000A0000;
+pub const EFI_SOFTWARE_AL: u32 = EFI_SOFTWARE | 0x000B0000;
+pub const EFI_SOFTWARE_EBC_EXCEPTION: u32 = EFI_SOFTWARE | 0x000C0000;
+pub const EFI_SOFTWARE_IA32_EXCEPTION: u32 = EFI_SOFTWARE | 0x000D0000;
+pub const EFI_SOFTWARE_IPF_EXCEPTION: u32 = EFI_SOFTWARE | 0x000E0000;
+pub const EFI_SOFTWARE_PEI_SERVICE: u32 = EFI_SOFTWARE | 0x000F0000;
+pub const EFI_SOFTWARE_EFI_BOOT_SERVICE: u32 = EFI_SOFTWARE | 0x00100000;
+pub const EFI_SOFTWARE_EFI_RUNTIME_SERVICE: u32 = EFI_SOFTWARE | 0x00110000;
+pub const EFI_SOFTWARE_EFI_DXE_SERVICE: u32 = EFI_SOFTWARE | 0x00120000;
+pub const EFI_SOFTWARE_X64_EXCEPTION: u32 = EFI_SOFTWARE | 0x00130000;
+pub const EFI_SOFTWARE_ARM_EXCEPTION: u32 = EFI_SOFTWARE | 0x00140000;
+
+///
+/// Debug Code definitions for all classes and subclass.
+/// Only one debug code is defined at this point and should
+/// be used for anything that is sent to the debug stream.
+///
+pub const EFI_DC_UNSPECIFIED: u32 = 0x0;
+
+///
+/// General partitioning scheme for Progress and Error Codes are:
+///   - 0x0000-0x0FFF    Shared by all sub-classes in a given class.
+///   - 0x1000-0x7FFF    Subclass Specific.
+///   - 0x8000-0xFFFF    OEM specific.
+pub const EFI_SUBCLASS_SPECIFIC: u32 = 0x1000;
+pub const EFI_OEM_SPECIFIC: u32 = 0x8000;
+
+pub const EFI_SW_BS_PC_RAISE_TPL: u32 = EFI_SUBCLASS_SPECIFIC;
+pub const EFI_SW_BS_PC_RESTORE_TPL: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000001;
+pub const EFI_SW_BS_PC_ALLOCATE_PAGES: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000002;
+pub const EFI_SW_BS_PC_FREE_PAGES: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000003;
+pub const EFI_SW_BS_PC_GET_MEMORY_MAP: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000004;
+pub const EFI_SW_BS_PC_ALLOCATE_POOL: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000005;
+pub const EFI_SW_BS_PC_FREE_POOL: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000006;
+pub const EFI_SW_BS_PC_CREATE_EVENT: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000007;
+pub const EFI_SW_BS_PC_SET_TIMER: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000008;
+pub const EFI_SW_BS_PC_WAIT_FOR_EVENT: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000009;
+pub const EFI_SW_BS_PC_SIGNAL_EVENT: u32 = EFI_SUBCLASS_SPECIFIC | 0x0000000A;
+pub const EFI_SW_BS_PC_CLOSE_EVENT: u32 = EFI_SUBCLASS_SPECIFIC | 0x0000000B;
+pub const EFI_SW_BS_PC_CHECK_EVENT: u32 = EFI_SUBCLASS_SPECIFIC | 0x0000000C;
+pub const EFI_SW_BS_PC_INSTALL_PROTOCOL_INTERFACE: u32 = EFI_SUBCLASS_SPECIFIC | 0x0000000D;
+pub const EFI_SW_BS_PC_REINSTALL_PROTOCOL_INTERFACE: u32 = EFI_SUBCLASS_SPECIFIC | 0x0000000E;
+pub const EFI_SW_BS_PC_UNINSTALL_PROTOCOL_INTERFACE: u32 = EFI_SUBCLASS_SPECIFIC | 0x0000000F;
+pub const EFI_SW_BS_PC_HANDLE_PROTOCOL: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000010;
+pub const EFI_SW_BS_PC_PC_HANDLE_PROTOCOL: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000011;
+pub const EFI_SW_BS_PC_REGISTER_PROTOCOL_NOTIFY: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000012;
+pub const EFI_SW_BS_PC_LOCATE_HANDLE: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000013;
+pub const EFI_SW_BS_PC_INSTALL_CONFIGURATION_TABLE: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000014;
+pub const EFI_SW_BS_PC_LOAD_IMAGE: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000015;
+pub const EFI_SW_BS_PC_START_IMAGE: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000016;
+pub const EFI_SW_BS_PC_EXIT: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000017;
+pub const EFI_SW_BS_PC_UNLOAD_IMAGE: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000018;
+pub const EFI_SW_BS_PC_EXIT_BOOT_SERVICES: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000019;
+pub const EFI_SW_BS_PC_GET_NEXT_MONOTONIC_COUNT: u32 = EFI_SUBCLASS_SPECIFIC | 0x0000001A;
+pub const EFI_SW_BS_PC_STALL: u32 = EFI_SUBCLASS_SPECIFIC | 0x0000001B;
+pub const EFI_SW_BS_PC_SET_WATCHDOG_TIMER: u32 = EFI_SUBCLASS_SPECIFIC | 0x0000001C;
+pub const EFI_SW_BS_PC_CONNECT_CONTROLLER: u32 = EFI_SUBCLASS_SPECIFIC | 0x0000001D;
+pub const EFI_SW_BS_PC_DISCONNECT_CONTROLLER: u32 = EFI_SUBCLASS_SPECIFIC | 0x0000001E;
+pub const EFI_SW_BS_PC_OPEN_PROTOCOL: u32 = EFI_SUBCLASS_SPECIFIC | 0x0000001F;
+pub const EFI_SW_BS_PC_CLOSE_PROTOCOL: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000020;
+pub const EFI_SW_BS_PC_OPEN_PROTOCOL_INFORMATION: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000021;
+pub const EFI_SW_BS_PC_PROTOCOLS_PER_HANDLE: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000022;
+pub const EFI_SW_BS_PC_LOCATE_HANDLE_BUFFER: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000023;
+pub const EFI_SW_BS_PC_LOCATE_PROTOCOL: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000024;
+pub const EFI_SW_BS_PC_INSTALL_MULTIPLE_INTERFACES: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000025;
+pub const EFI_SW_BS_PC_UNINSTALL_MULTIPLE_INTERFACES: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000026;
+pub const EFI_SW_BS_PC_CALCULATE_CRC_32: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000027;
+pub const EFI_SW_BS_PC_COPY_MEM: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000028;
+pub const EFI_SW_BS_PC_SET_MEM: u32 = EFI_SUBCLASS_SPECIFIC | 0x00000029;
+pub const EFI_SW_BS_PC_CREATE_EVENT_EX: u32 = EFI_SUBCLASS_SPECIFIC | 0x0000002A;
+
+/// The definition of the status code extended data header. The data will follow HeaderSize bytes from the
+/// beginning of the structure and is Size bytes long.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section III-6.6.2.1
+#[repr(C)]
+pub struct EfiStatusCodeData {
+  pub header_size: u16,
+  pub size: u16,
+  pub r#type: efi::Guid,
+}
+
+/// Provides an interface that a software module can call to report a status code.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-14.2.1
+pub type ReportStatusCode =
+  extern "efiapi" fn(u32, u32, u32, *const efi::Guid, *const EfiStatusCodeData) -> efi::Status;
+
+/// Provides the service required to report a status code to the platform firmware.
+/// This protocol must be produced by a runtime DXE driver.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-14.2.1
+#[repr(C)]
+pub struct Protocol {
+  pub report_status_code: ReportStatusCode,
+}

--- a/src/protocols/timer.rs
+++ b/src/protocols/timer.rs
@@ -1,0 +1,117 @@
+//! Timer Architectural Protocol
+//!
+//! Used to set up a periodic timer interrupt using a platform specific timer, and a processor-specific interrupt
+//! vector. This protocol enables the use of the SetTimer() Boot Service.
+//!
+//! See <https://uefi.org/specs/PI/1.8A/V2_DXE_Architectural_Protocols.html#timer-architectural-protocol>
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+use r_efi::efi;
+
+pub const PROTOCOL_GUID: efi::Guid =
+  efi::Guid::from_fields(0x26BACCB3, 0x6F42, 0x11D4, 0xBC, 0xE7, &[0x00, 0x80, 0xC7, 0x3C, 0x88, 0x81]);
+
+/// A function of this type is called when a timer interrupt fires.  This
+/// function executes at TPL_HIGH_LEVEL.  The DXE Core will register a function
+/// of this type to be called for the timer interrupt, so it can know how much
+/// time has passed.  This information is used to signal timer based events.
+///
+/// * time -  Time since the last timer interrupt in 100 ns units. This will
+///                   typically be TimerPeriod, but if a timer interrupt is missed, and the
+///                   EFI_TIMER_ARCH_PROTOCOL driver can detect missed interrupts, then Time
+///                   will contain the actual amount of time since the last interrupt.
+pub type EfiTimerNotify = extern "efiapi" fn(time: u64);
+
+/// This function registers the handler NotifyFunction so it is called every time
+/// the timer interrupt fires.  It also passes the amount of time since the last
+/// handler call to the NotifyFunction.  If NotifyFunction is NULL, then the
+/// handler is unregistered.  If the handler is registered, then EFI_SUCCESS is
+/// returned.  If the CPU does not support registering a timer interrupt handler,
+/// then EFI_UNSUPPORTED is returned.  If an attempt is made to register a handler
+/// when a handler is already registered, then EFI_ALREADY_STARTED is returned.
+/// If an attempt is made to unregister a handler when a handler is not registered,
+/// then EFI_INVALID_PARAMETER is returned.  If an error occurs attempting to
+/// register the NotifyFunction with the timer interrupt, then EFI_DEVICE_ERROR
+/// is returned.
+/// * this -            The EFI_TIMER_ARCH_PROTOCOL instance.
+/// * notify_function - The function to call when a timer interrupt fires. This
+///                     function executes at TPL_HIGH_LEVEL. The DXE Core will
+///                     register a handler for the timer interrupt, so it can know
+///                     how much time has passed. This information is used to
+///                     signal timer based events. NULL will unregister the handler.
+/// * @retval - EFI_SUCCESS: The timer handler was registered.
+/// * @retval - EFI_UNSUPPORTED: The platform does not support timer interrupts.
+/// * @retval - EFI_ALREADY_STARTED: NotifyFunction is not NULL, and a handler is already
+///                                  registered.
+/// * @retval - EFI_INVALID_PARAMETER: NotifyFunction is NULL, and a handler was not
+///                                    previously registered.
+/// * @retval - EFI_DEVICE_ERROR: The timer handler could not be registered.
+pub type EfiTimerRegisterHandler =
+  extern "efiapi" fn(this: *mut Protocol, notify_function: EfiTimerNotify) -> efi::Status;
+
+/// This function adjusts the period of timer interrupts to the value specified
+/// by TimerPeriod.  If the timer period is updated, then the selected timer
+/// period is stored in EFI_TIMER.TimerPeriod, and EFI_SUCCESS is returned.  If
+/// the timer hardware is not programmable, then EFI_UNSUPPORTED is returned.
+/// If an error occurs while attempting to update the timer period, then the
+/// timer hardware will be put back in its state prior to this call, and
+/// EFI_DEVICE_ERROR is returned.  If TimerPeriod is 0, then the timer interrupt
+/// is disabled.  This is not the same as disabling the CPU's interrupts.
+/// Instead, it must either turn off the timer hardware, or it must adjust the
+/// interrupt controller so that a CPU interrupt is not generated when the timer
+/// interrupt fires.
+/// * this - The EFI_TIMER_ARCH_PROTOCOL instance.
+/// * timer_period - The rate to program the timer interrupt in 100 nS units. If
+///                  the timer hardware is not programmable, then EFI_UNSUPPORTED is
+///                  returned. If the timer is programmable, then the timer period
+///                  will be rounded up to the nearest timer period that is supported
+///                  by the timer hardware. If TimerPeriod is set to 0, then the
+///                  timer interrupts will be disabled.
+/// * @retval - EFI_SUCCESS: The timer period was changed.
+/// * @retval - EFI_UNSUPPORTED: The platform cannot change the period of the timer interrupt.
+/// * @retval - EFI_DEVICE_ERROR: The timer period could not be changed due to a device error.
+pub type EfiTimerSetTimerPeriod = extern "efiapi" fn(this: *mut Protocol, timer_period: u64) -> efi::Status;
+
+/// This function retrieves the period of timer interrupts in 100 ns units,
+/// returns that value in TimerPeriod, and returns EFI_SUCCESS.  If TimerPeriod
+/// is NULL, then EFI_INVALID_PARAMETER is returned.  If a TimerPeriod of 0 is
+/// returned, then the timer is currently disabled.
+/// * this - The EFI_TIMER_ARCH_PROTOCOL instance.
+/// * timer_period - A pointer to the timer period to retrieve in 100 ns units. If
+///                  0 is returned, then the timer is currently disabled.
+/// * @retval - EFI_SUCCESS: The timer period was returned in TimerPeriod.
+/// * @retval - EFI_INVALID_PARAMETER: TimerPeriod is NULL.
+pub type EfiTimerGetTimerPeriod = extern "efiapi" fn(*mut Protocol, *mut u64) -> efi::Status;
+
+/// This function generates a soft timer interrupt. If the platform does not support soft
+/// timer interrupts, then EFI_UNSUPPORTED is returned. Otherwise, EFI_SUCCESS is returned.
+/// If a handler has been registered through the EFI_TIMER_ARCH_PROTOCOL.RegisterHandler()
+/// service, then a soft timer interrupt will be generated. If the timer interrupt is
+/// enabled when this service is called, then the registered handler will be invoked. The
+/// registered handler should not be able to distinguish a hardware-generated timer
+/// interrupt from a software-generated timer interrupt.
+/// * this - The EFI_TIMER_ARCH_PROTOCOL instance.
+/// * @retval - EFI_SUCCESS: The soft timer interrupt was generated.
+/// * @retval - EFI_UNSUPPORTED: The platform does not support the generation of soft timer interrupts.
+pub type EfiTimerGenerateSoftInterrupt = extern "efiapi" fn(this: *mut Protocol) -> efi::Status;
+
+/// This protocol provides the services to initialize a periodic timer interrupt, and to register a handler
+/// that is called each time the time interrupt fires.  It may also provide a service to adjust the rate of the
+/// periodic timer interrupt.  When a timer interrupt occurs, the handler is passed the amount of time that has
+/// passed since the previous timer interrupt.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.10.1
+#[repr(C)]
+pub struct Protocol {
+  pub register_handler: EfiTimerRegisterHandler,
+  pub set_timer_period: EfiTimerSetTimerPeriod,
+  pub get_timer_period: EfiTimerGetTimerPeriod,
+  pub generate_soft_interrupt: EfiTimerGenerateSoftInterrupt,
+}

--- a/src/protocols/watchdog.rs
+++ b/src/protocols/watchdog.rs
@@ -1,0 +1,56 @@
+//! Watchdog Architectural Protocol
+//!
+//! Used to implement the Boot Service SetWatchdogTimer() . The watchdog timer may be implemented in
+//! software using Boot Services, or it may be implemented with specialized hardware. The protocol provides a service
+//! to register a handler when the watchdog timer fires and a service to set the amount of time to wait before the
+//! watchdog timer is fired.
+//!
+//! See <https://uefi.org/specs/PI/1.8A/V2_DXE_Architectural_Protocols.html#watchdog-timer-architectural-protocol>
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+use r_efi::efi;
+
+/// Watchdog Architectrural Protocol GUID
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.14.1
+pub const PROTOCOL_GUID: efi::Guid =
+  efi::Guid::from_fields(0x665E3FF5, 0x46CC, 0x11d4, 0x9A, 0x38, &[0x00, 0x90, 0x27, 0x3F, 0xC1, 0x4D]);
+
+/// Function type definition for watchdog timer notify.
+pub type WatchdogTimerNotify = extern "efiapi" fn(u64);
+
+/// Registers a handler that is to be invoked when the watchdog timer fires.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.14.2
+pub type RegisterHandler = extern "efiapi" fn(*const Protocol, WatchdogTimerNotify) -> efi::Status;
+
+/// Sets the amount of time in the future to fire the watchdog timer.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.14.3
+pub type SetTimerPeriod = extern "efiapi" fn(*const Protocol, u64) -> efi::Status;
+
+/// Retrieves the amount of time in 100 ns units that the system will wait before firing the watchdog timer.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.14.4
+pub type GetTimerPeriod = extern "efiapi" fn(*const Protocol, *mut u64) -> efi::Status;
+
+/// Used to program the watchdog timer and optionally register a handler when the watchdog timer fires.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.8, Section II-12.14.1
+#[repr(C)]
+pub struct Protocol {
+  pub register_handler: RegisterHandler,
+  pub set_timer_period: SetTimerPeriod,
+  pub get_timer_period: GetTimerPeriod,
+}

--- a/test_resources/DXEFV_expected_values.yml
+++ b/test_resources/DXEFV_expected_values.yml
@@ -1,0 +1,42 @@
+total_number_of_files: 169
+files_to_test:
+  # GUID of the File (need to be uppercase)
+  "23C9322F-2AF2-476A-BC4C-26BC88266C71":
+    base_address: 0xB8
+    file_type: 0x5
+    attributes: 0x0
+    # Body size in UEFITool
+    data_size: 0x14CA26
+    # Full size in UEFITool
+    size: 0x14CA3E
+    # Number of section that the file has
+    number_of_sections: 3
+    sections:
+      # Index of the section in the file (Not required to defined every section)
+      0:
+        section_type: "Pe32"
+        base_address: 0xD0
+        size: 0x14CA04
+      1:
+        section_type: "UserInterface"
+        base_address: 0x14CAD4
+        size: 0x14
+        # Needed only if the file has a text information.
+        text: "DxeRust"
+      2:
+        section_type: "Version"
+        base_address: 0x14CAE8
+        size: 0xE
+
+  "E3624086-4FCD-446E-9D07-B6B913792071":
+    base_address: 0x4B6830
+    file_type: 0x9
+    attributes: 0x0
+    data_size: 0x11C9F
+    size: 0x11CB7
+    number_of_sections: 1
+    sections:
+      0:
+        section_type: "Compression"
+        base_address: 0x4B6848
+        size: 0x11C9F


### PR DESCRIPTION
Adds a new crate to support Rust projects that use the Platform
Initialization (PI) Specification maintained by the UEFI Forum.

The primary focus is to provide rust types and constants to build
a PI Specification compliant firmware, functionality is allowed to
be implemented around those types as well. Code implementation must
be applicable to any PI spec compliant firmware that may need the
associated functionality.

Refer to the Platform Initialization (PI) Specification for more
background on the specification https://uefi.org/specs/PI/1.8A/.

The PI Specification describes a number of boot phases and concepts
used across those boot phases referred to as "Shared Architectural
Elements". The implementation predominantly focuses on the DXE phase
at this time. This includes shared elements used in other stages such
as the HOBs and firmware storage. Contributions to expand coverage of
the specification are welcome.

The overall structure and design of the crate is subject to breaking
changes at this time. The code is being shared for wider feedback and
collaboration that might result in fundamental changes to the
organization of content. These details will be documented and managed
using appropriately versioned releases of the crate to reflect the
degree of change.