### PR TITLE
Run formatting with nightly rustfmt

### DIFF
--- a/src/fw_fs/ffs.rs
+++ b/src/fw_fs/ffs.rs
@@ -23,19 +23,21 @@ use core::{
 use r_efi::efi;
 use uuid::Uuid;
 
-use crate::address_helper::align_up;
-use crate::fw_fs::{
-  ffs::{
-    attributes::raw as FfsRawAttribute,
-    file::{raw::r#type as FfsFileRawType, Header as FfsFileHeader, Type as FfsFileType},
-    section as FfsSection,
-    section::{header as FfsSectionHeader, raw_type as FfsSectionRawType},
+use crate::{
+  address_helper::align_up,
+  fw_fs::{
+    ffs::{
+      attributes::raw as FfsRawAttribute,
+      file::{raw::r#type as FfsFileRawType, Header as FfsFileHeader, Type as FfsFileType},
+      section as FfsSection,
+      section::{header as FfsSectionHeader, raw_type as FfsSectionRawType},
+    },
+    fv::{
+      file::{raw::attribute as FvRawAttribute, EfiFvFileAttributes},
+      FirmwareVolume, Header as FvHeader,
+    },
+    fvb::attributes::raw::fvb2 as Fvb2RawAttributes,
   },
-  fv::{
-    file::{raw::attribute as FvRawAttribute, EfiFvFileAttributes},
-    FirmwareVolume, Header as FvHeader,
-  },
-  fvb::attributes::raw::fvb2 as Fvb2RawAttributes,
 };
 
 #[derive(Copy, Clone)]

--- a/src/hob.rs
+++ b/src/hob.rs
@@ -1090,7 +1090,10 @@ impl<'a> Iterator for HobIter<'a> {
 
 #[cfg(test)]
 mod tests {
-  use crate::{hob, hob::Hob, hob::HobList, hob::HobTrait};
+  use crate::{
+    hob,
+    hob::{Hob, HobList, HobTrait},
+  };
 
   use core::{
     ffi::c_void,


### PR DESCRIPTION
## Description

Format only. Formatting changes from running with nightly rustfmt to fully apply all rules specified in `rustfmt.toml`. No functional changes. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

No functional change.

## Integration Instructions

N/A