### PR TITLE
FFS refactor to add support for large files/sections

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -26,6 +26,7 @@
     "dxefv",
     "efiapi",
     "eficall",
+    "GIGANTOR",
     "indoc",
     "rustc",
     "rustfmt",

--- a/src/fw_fs.rs
+++ b/src/fw_fs.rs
@@ -23,7 +23,7 @@ pub use ffs::{
   },
   section::{
     header as FfsSectionHeader, raw_type as FfsSectionRawType, raw_type::encapsulated as FfsEncapsulatedSectionRawType,
-    EfiSectionType, Generic as FfsSectionGeneric, Type as FfsSectionType,
+    EfiSectionType, Type as FfsSectionType,
   },
   File as FfsFile, Section as FfsSection,
 };

--- a/src/fw_fs/ffs.rs
+++ b/src/fw_fs/ffs.rs
@@ -12,6 +12,7 @@
 
 pub mod attributes;
 pub mod file;
+pub mod guid;
 pub mod section;
 
 use core::{

--- a/src/fw_fs/ffs.rs
+++ b/src/fw_fs/ffs.rs
@@ -207,8 +207,8 @@ pub(crate) struct FileIterator {
 }
 
 impl FileIterator {
-  pub fn new(start_file: File) -> FileIterator {
-    FileIterator { next_ffs: Some(start_file) }
+  pub fn new(start_file: Option<File>) -> FileIterator {
+    FileIterator { next_ffs: start_file }
   }
 }
 

--- a/src/fw_fs/ffs/file.rs
+++ b/src/fw_fs/ffs/file.rs
@@ -90,8 +90,9 @@ pub enum State {
   HeaderInvalid = raw::state::HEADER_INVALID,
 }
 
+// EFI_FFS_FILE_HEADER
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct Header {
   pub(crate) name: efi::Guid,
   pub(crate) integrity_check_header: u8,
@@ -100,4 +101,12 @@ pub(crate) struct Header {
   pub(crate) attributes: u8,
   pub(crate) size: [u8; 3],
   pub(crate) state: u8,
+}
+
+// EFI_FFS_FILE_HEADER
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Header2 {
+  pub(crate) header: Header,
+  pub(crate) extended_size: u64,
 }

--- a/src/fw_fs/ffs/guid.rs
+++ b/src/fw_fs/ffs/guid.rs
@@ -1,0 +1,24 @@
+//! Firmware File System (FFS) Guid Definitions
+//!
+//! Based on the values defined in the UEFI Platform Initialization (PI) Specification V1.8A Section 3.2.2.
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+use r_efi::efi;
+
+// {8C8CE578-8A3D-4F1C-9935-896185C32DD3}
+pub const EFI_FIRMWARE_FILE_SYSTEM2_GUID: efi::Guid =
+  efi::Guid::from_fields(0x8c8ce578, 0x8a3d, 0x4f1c, 0x99, 0x35, &[0x89, 0x61, 0x85, 0xc3, 0x2d, 0xd3]);
+
+// {5473C07A-3DCB-4DCA-BD6F-1E9689E7349A}
+pub const EFI_FIRMWARE_FILE_SYSTEM3_GUID: efi::Guid =
+  efi::Guid::from_fields(0x5473c07a, 0x3dcb, 0x4dca, 0xbd, 0x6f, &[0x1e, 0x96, 0x89, 0xe7, 0x34, 0x9a]);
+
+// {1BA0062E-C779-4582-8566-336AE8F78F09}
+pub const EFI_FFS_VOLUME_TOP_FILE_GUID: efi::Guid =
+  efi::Guid::from_fields(0x1ba0062e, 0xc779, 0x4582, 0x85, 0x66, &[0x33, 0x6a, 0xe8, 0xf7, 0x8f, 0x9]);

--- a/src/fw_fs/ffs/section.rs
+++ b/src/fw_fs/ffs/section.rs
@@ -66,16 +66,24 @@ pub mod header {
   /// EFI_COMMON_SECTION_HEADER
   #[repr(C)]
   #[derive(Debug)]
-  pub struct Common {
+  pub struct CommonSectionHeaderStandard {
     pub size: [u8; 3],
     pub section_type: u8,
+  }
+
+  /// EFI_COMMON_SECTION_HEADER2
+  #[repr(C)]
+  #[derive(Debug)]
+  pub struct CommonSectionHeaderExtended {
+    pub size: [u8; 3],
+    pub section_type: u8,
+    pub extended_size: u32,
   }
 
   /// EFI_COMPRESSION_SECTION
   #[repr(C)]
   #[derive(Debug)]
   pub struct Compression {
-    pub common_header: Common,
     pub uncompressed_length: u32,
     pub compression_type: u8,
   }
@@ -84,123 +92,23 @@ pub mod header {
   #[repr(C)]
   #[derive(Debug)]
   pub struct GuidDefined {
-    pub common_header: Common,
     pub section_definition_guid: Guid,
     pub data_offset: u16,
     pub attributes: u16,
     // Guid-specific header fields.
   }
 
-  /// EFI_DISPOSABLE_SECTION
-  #[repr(C)]
-  #[derive(Debug)]
-  pub struct Disposable {
-    pub common_header: Common,
-  }
-
-  /// EFI_PE32_SECTION
-  #[repr(C)]
-  #[derive(Debug)]
-  pub struct Pe32 {
-    pub common_header: Common,
-  }
-
-  /// EFI_PIC_SECTION
-  #[repr(C)]
-  #[derive(Debug)]
-  pub struct Pic {
-    pub common_header: Common,
-  }
-
-  /// EFI_TE_SECTION
-  #[repr(C)]
-  #[derive(Debug)]
-  pub struct Te {
-    pub common_header: Common,
-  }
-
-  /// EFI_DXE_DEPEX_SECTION
-  #[repr(C)]
-  #[derive(Debug)]
-  pub struct DxeDepex {
-    pub common_header: Common,
-  }
-
   /// EFI_VERSION_SECTION
   #[repr(C)]
   #[derive(Debug)]
   pub struct Version {
-    pub common_header: Common,
     pub build_number: u16,
-  }
-
-  /// EFI_USER_INTERFACE_SECTION
-  #[repr(C)]
-  #[derive(Debug)]
-  pub struct UserInterface {
-    pub common_header: Common,
-  }
-
-  /// EFI_COMPATIBILITY16_SECTION
-  #[repr(C)]
-  #[derive(Debug)]
-  pub struct Compatibility16 {
-    pub common_header: Common,
-  }
-
-  /// EFI_FIRMWARE_VOLUME_IMAGE_SECTION
-  #[repr(C)]
-  #[derive(Debug)]
-  pub struct FirmwareVolumeImage {
-    pub common_header: Common,
   }
 
   /// EFI_FREEFORM_SUBTYPE_GUID_SECTION
   #[repr(C)]
   #[derive(Debug)]
   pub struct FreeformSubtypeGuid {
-    pub common_header: Common,
     pub sub_type_guid: Guid,
   }
-
-  /// EFI_RAW_SECTION
-  #[repr(C)]
-  #[derive(Debug)]
-  pub struct Raw {
-    pub common_header: Common,
-  }
-
-  /// EFI_PEI_DEPEX_SECTION
-  #[repr(C)]
-  #[derive(Debug)]
-  pub struct PeiDepex {
-    pub common_header: Common,
-  }
-
-  /// EFI_MM_DEPEX_SECTION
-  #[repr(C)]
-  #[derive(Debug)]
-  pub struct MmDepex {
-    pub common_header: Common,
-  }
-}
-
-#[derive(Debug, Copy, Clone)]
-pub enum Generic {
-  Compression(*const header::Compression),
-  GuidDefined(*const header::GuidDefined),
-  Disposable(*const header::Disposable),
-  Pe32(*const header::Pe32),
-  Pic(*const header::Pic),
-  Te(*const header::Te),
-  DxeDepex(*const header::DxeDepex),
-  Version(*const header::Version),
-  UserInterface(*const header::UserInterface),
-  Compatibility16(*const header::Compatibility16),
-  FirmwareVolumeImage(*const header::FirmwareVolumeImage),
-  FreeformSubtypeGuid(*const header::FreeformSubtypeGuid),
-  Raw(*const header::Raw),
-  PeiDepex(*const header::PeiDepex),
-  MmDepex(*const header::MmDepex),
-  Unknown(*const header::Common),
 }

--- a/src/fw_fs/fv.rs
+++ b/src/fw_fs/fv.rs
@@ -145,15 +145,15 @@ impl FirmwareVolume {
     Ok(FirmwareVolume { fv_header: fv_header.as_ref().unwrap() })
   }
 
-  fn ext_header(&self) -> Option<*const ExtHeader> {
+  fn ext_header(&self) -> Option<&'static ExtHeader> {
     let ext_header_offset = self.fv_header.ext_header_offset as u64;
     if ext_header_offset == 0 {
       return None;
     }
-    Some((self.base_address() + ext_header_offset) as *const ExtHeader)
+    unsafe { ((self.base_address() + ext_header_offset) as *const ExtHeader).as_ref() }
   }
 
-  fn block_map(&self) -> &[BlockMapEntry] {
+  fn block_map(&self) -> &'static [BlockMapEntry] {
     let block_map_start = self.fv_header.block_map.as_ptr();
     let mut count = 0;
     let mut current_block_map_ptr = block_map_start;
@@ -170,7 +170,7 @@ impl FirmwareVolume {
 
   pub fn fv_name(&self) -> Option<efi::Guid> {
     if let Some(ext_header) = self.ext_header() {
-      return unsafe { Some((*ext_header).fv_name) };
+      return Some(ext_header.fv_name);
     }
     None
   }
@@ -179,10 +179,8 @@ impl FirmwareVolume {
     let mut ffs_address = self.fv_header as *const Header as u64;
     if let Some(ext_header) = self.ext_header() {
       // if ext header exists, then file starts after ext header
-      unsafe {
-        ffs_address += (*self.fv_header).ext_header_offset as u64;
-        ffs_address += (*ext_header).ext_header_size as u64;
-      }
+      ffs_address += self.fv_header.ext_header_offset as u64;
+      ffs_address += ext_header.ext_header_size as u64;
     } else {
       // otherwise the file starts after the main header.
       ffs_address += self.fv_header.header_length as u64

--- a/src/fw_fs/fv.rs
+++ b/src/fw_fs/fv.rs
@@ -194,7 +194,7 @@ impl FirmwareVolume {
     if ffs_address + mem::size_of::<FfsFileHeader>() as u64 >= self.top_address() {
       None
     } else {
-      Some(FfsFile::new(*self, ffs_address))
+      unsafe { FfsFile::new(*self, ffs_address).ok() }
     }
   }
 

--- a/src/fw_fs/fv.rs
+++ b/src/fw_fs/fv.rs
@@ -81,6 +81,7 @@ pub(crate) struct ExtHeader {
   pub(crate) ext_header_size: u32,
 }
 
+/// Firmware Volume
 #[derive(Copy, Clone)]
 pub struct FirmwareVolume {
   fv_header: &'static Header,
@@ -171,6 +172,7 @@ impl FirmwareVolume {
     }
   }
 
+  /// Returns the GUID name of the Firmware Volume
   pub fn fv_name(&self) -> Option<efi::Guid> {
     if let Some(ext_header) = self.ext_header() {
       return Some(ext_header.fv_name);
@@ -178,6 +180,7 @@ impl FirmwareVolume {
     None
   }
 
+  /// Returns the first file in the Firmware Volume
   pub fn first_ffs_file(&self) -> Option<FfsFile> {
     let mut ffs_address = self.fv_header as *const Header as u64;
     if let Some(ext_header) = self.ext_header() {
@@ -198,22 +201,27 @@ impl FirmwareVolume {
     }
   }
 
+  /// Returns an iterator over all files in the firmware volume.
   pub fn ffs_files(&self) -> impl Iterator<Item = FfsFile> {
     FfsFileIterator::new(self.first_ffs_file())
   }
 
+  /// Returns the base address in memory of the firmware volume.
   pub fn base_address(&self) -> efi::PhysicalAddress {
     self.fv_header as *const Header as efi::PhysicalAddress
   }
 
+  /// returns the memory address of the end of the firmware volume (not inclusive)
   pub fn top_address(&self) -> efi::PhysicalAddress {
     self.base_address() + self.fv_header.fv_length
   }
 
+  /// returns the Firmware Volume Attributes
   pub fn attributes(&self) -> EfiFvbAttributes2 {
     self.fv_header.attributes
   }
 
+  /// returns the (linear block offset from FV base, block_size, remaining_blocks) given an LBA.
   pub fn get_lba_info(&self, lba: u32) -> Result<(u32, u32, u32), ()> {
     let block_map = self.block_map();
 

--- a/src/fw_fs/fv.rs
+++ b/src/fw_fs/fv.rs
@@ -314,87 +314,11 @@ mod unit_tests {
     assert_eq!(FfsRawFileType::ALL, 0x00);
   }
 
-  #[test]
-  fn test_firmware_volume() -> Result<(), Box<dyn Error>> {
-    let root = Path::new(&env::var("CARGO_MANIFEST_DIR")?).join("test_resources");
-
-    let fv_bytes = fs::read(root.join("DXEFV.Fv"))?;
-    let fv = unsafe { FirmwareVolume::new(fv_bytes.as_ptr() as efi::PhysicalAddress).unwrap() };
-
-    let mut expected_values =
-      serde_yaml::from_reader::<File, TargetValues>(File::open(root.join("DXEFV_expected_values.yml"))?)?;
-
-    let mut count = 0;
-    for ffs_file in fv.ffs_files() {
-      count += 1;
-      let file_name = Uuid::from_bytes_le(*ffs_file.file_name().as_bytes()).to_string().to_uppercase();
-      let sections = ffs_file.ffs_sections().collect::<Vec<_>>();
-      if let Some(mut target) = expected_values.files_to_test.remove(&file_name) {
-        assert_eq!(
-          target.base_address,
-          ffs_file.base_address() - fv_bytes.as_ptr() as u64,
-          "[{file_name}] Error with the file Base Address"
-        );
-        assert_eq!(target.file_type, ffs_file.file_type_raw(), "[{file_name}] Error with the file type.");
-        assert_eq!(target.attributes, ffs_file.file_attributes_raw(), "[{file_name}] Error with the file attributes.");
-        assert_eq!(target.size, ffs_file.file_size(), "[{file_name}] Error with the file size (Full size).");
-        assert_eq!(
-          target.data_size,
-          ffs_file.file_data_size() as usize,
-          "[{file_name}] Error with the file data size (Body size)."
-        );
-        assert_eq!(
-          target.number_of_sections,
-          sections.len(),
-          "[{file_name}] Error with the number of section in the File"
-        );
-
-        for (idx, section) in sections.iter().enumerate() {
-          if let Some(target) = target.sections.remove(&idx) {
-            assert_eq!(
-              target.base_address,
-              section.base_address() - fv_bytes.as_ptr() as u64,
-              "[{file_name}, section: {idx}] Error with the section Base Address"
-            );
-            assert_eq!(
-              target.section_type,
-              section.section_type(),
-              "[{file_name}, section: {idx}] Error with the section Type"
-            );
-            assert_eq!(
-              target.size,
-              section.section_size(),
-              "[{file_name}, section: {idx}] Error with the section Size"
-            );
-            assert_eq!(
-              target.text,
-              extract_text_from_section(section),
-              "[{file_name}, section: {idx}] Error with the section Text"
-            );
-          }
-        }
-
-        assert!(target.sections.is_empty(), "Some section use case has not been run.");
-      }
-    }
-    assert_eq!(
-      expected_values.total_number_of_files, count,
-      "The number of file found does not match the expected one."
-    );
-    assert!(expected_values.files_to_test.is_empty(), "Some file use case has not been run.");
-    Ok(())
-  }
-
-  #[test]
-  fn test_giant_firmware_volume() -> Result<(), Box<dyn Error>> {
-    let root = Path::new(&env::var("CARGO_MANIFEST_DIR")?).join("test_resources");
-
-    let fv_bytes = fs::read(root.join("GIGANTOR.Fv"))?;
-    let fv = unsafe { FirmwareVolume::new(fv_bytes.as_ptr() as efi::PhysicalAddress).unwrap() };
-
-    let mut expected_values =
-      serde_yaml::from_reader::<File, TargetValues>(File::open(root.join("GIGANTOR_expected_values.yml"))?)?;
-
+  fn test_firmware_volume_worker(
+    fv_bytes: Vec<u8>,
+    fv: FirmwareVolume,
+    mut expected_values: TargetValues,
+  ) -> Result<(), Box<dyn Error>> {
     let mut count = 0;
     for ffs_file in fv.ffs_files() {
       count += 1;
@@ -464,6 +388,32 @@ mod unit_tests {
     } else {
       None
     }
+  }
+
+  #[test]
+  fn test_firmware_volume() -> Result<(), Box<dyn Error>> {
+    let root = Path::new(&env::var("CARGO_MANIFEST_DIR")?).join("test_resources");
+
+    let fv_bytes = fs::read(root.join("DXEFV.Fv"))?;
+    let fv = unsafe { FirmwareVolume::new(fv_bytes.as_ptr() as efi::PhysicalAddress).unwrap() };
+
+    let expected_values =
+      serde_yaml::from_reader::<File, TargetValues>(File::open(root.join("DXEFV_expected_values.yml"))?)?;
+
+    test_firmware_volume_worker(fv_bytes, fv, expected_values)
+  }
+
+  #[test]
+  fn test_giant_firmware_volume() -> Result<(), Box<dyn Error>> {
+    let root = Path::new(&env::var("CARGO_MANIFEST_DIR")?).join("test_resources");
+
+    let fv_bytes = fs::read(root.join("GIGANTOR.Fv"))?;
+    let fv = unsafe { FirmwareVolume::new(fv_bytes.as_ptr() as efi::PhysicalAddress).unwrap() };
+
+    let expected_values =
+      serde_yaml::from_reader::<File, TargetValues>(File::open(root.join("GIGANTOR_expected_values.yml"))?)?;
+
+    test_firmware_volume_worker(fv_bytes, fv, expected_values)
   }
 
   #[test]

--- a/src/fw_fs/fv.rs
+++ b/src/fw_fs/fv.rs
@@ -18,7 +18,7 @@ extern crate alloc;
 use crate::address_helper::align_up;
 use alloc::string::ToString;
 use core::{fmt, slice};
-use r_efi::efi::Guid;
+use r_efi::efi;
 use uuid::Uuid;
 
 use crate::fw_fs::{
@@ -49,7 +49,7 @@ pub enum WritePolicy {
 #[derive(Debug)]
 pub struct Header {
   pub(crate) zero_vector: [u8; 16],
-  pub(crate) file_system_guid: Guid,
+  pub(crate) file_system_guid: efi::Guid,
   pub(crate) fv_length: u64,
   pub(crate) signature: u32,
   pub(crate) attributes: EfiFvbAttributes2,
@@ -72,7 +72,7 @@ pub(crate) struct BlockMapEntry {
 #[repr(C)]
 #[derive(Debug)]
 pub(crate) struct ExtHeader {
-  pub(crate) fv_name: Guid,
+  pub(crate) fv_name: efi::Guid,
   pub(crate) ext_header_size: u32,
 }
 
@@ -112,7 +112,7 @@ impl FirmwareVolume {
     }
   }
 
-  pub fn fv_name(&self) -> Option<Guid> {
+  pub fn fv_name(&self) -> Option<efi::Guid> {
     if let Some(ext_header) = self.ext_header() {
       return unsafe { Some((*ext_header).fv_name) };
     }

--- a/test_resources/GIGANTOR_expected_values.yml
+++ b/test_resources/GIGANTOR_expected_values.yml
@@ -1,0 +1,61 @@
+total_number_of_files: 3
+files_to_test:
+  # GUID of the File (need to be uppercase)
+  "8B02EFF4-7191-446A-AA33-90355378A5B0":
+    base_address: 0x78
+    file_type: 0x2
+    attributes: 0x01
+    # Body size in UEFITool
+    data_size: 0x200001A
+    # Full size in UEFITool
+    size: 0x200003A
+    # Number of section that the file has
+    number_of_sections: 2
+    sections:
+      # Index of the section in the file (Not required to defined every section)
+      0:
+        section_type: "Raw"
+        base_address: 0x98
+        size: 0x2000008
+      1:
+        section_type: "Raw"
+        base_address: 0x20000A0
+        size: 0x12
+  # GUID of the File (need to be uppercase)
+  "039BACD3-AFB5-4A0C-875B-97F1A1C4686E":
+    base_address: 0x20000B8
+    file_type: 0x2
+    attributes: 0x00
+    # Body size in UEFITool
+    data_size: 0x12
+    # Full size in UEFITool
+    size: 0x2A
+    # Number of section that the file has
+    number_of_sections: 1
+    sections:
+      # Index of the section in the file (Not required to defined every section)
+      0:
+        section_type: "Raw"
+        base_address: 0x20000D0
+        size: 0x12
+  # GUID of the File (need to be uppercase)
+  "DFC62C9E-A7E6-43AF-92A9-FA05A7B682D6":
+    base_address: 0x20000E8
+    file_type: 0x2
+    attributes: 0x01
+    # Body size in UEFITool
+    data_size: 0x200001C
+    # Full size in UEFITool
+    size: 0x200003C
+    # Number of section that the file has
+    number_of_sections: 2
+    sections:
+      # Index of the section in the file (Not required to defined every section)
+      0:
+        section_type: "Raw"
+        base_address: 0x2000108
+        size: 0x12
+      1:
+        section_type: "Raw"
+        base_address: 0x200011C
+        size: 0x2000008


### PR DESCRIPTION
## Description

This is a refactor of the FFS support to add support for large files/sections (i.e. EFI_FIRMWARE_FILESYSTEM_3). The previous implementation only supported small (less than 16MB) files/sections (i.e. EFI_FIRMWARE_FILESYSTEM_2). 

- [x] Impacts functionality?
  - Adds support for FFS 3.
- [ ] Impacts security?
- [x] Breaking change?
  - Significant refactor of API for accessing FFS objects.
- [x] Includes tests?
  - Added tests to verify FFS 3 large files.
- [x] Includes documentation?
  - updated rustdocs

## How This Was Tested

Unit tests pass. 

## Integration Instructions

Consumers of the affected modules will need to update to use the new APIs. 
