### PR TITLE
Fix warnings generated when compiling with rust toolchain 1.80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,14 @@ categories = ["embedded", "hardware-support", "no-std"]
 [dependencies]
 indoc = "2.0"
 num-traits = { version = "0.2", default-features = false }
-r-efi = { version = "5.0.0", default_features = false }
-uuid = { version = "1.8", default_features = false }
+r-efi = { version = "5.0.0", default-features = false }
+uuid = { version = "1.8", default-features = false }
 
 [dev-dependencies]
 serde = { version = "1.0.197", features = ["derive"]}
 serde_yaml = "0.9.34"
-brotli-decompressor = { version= "4.0.0", default_features = false}
+brotli-decompressor = { version= "4.0.0", default-features = false}
 alloc-no-stdlib = { version = "~2.0"}
+
+[features]
+nightly = []

--- a/src/fw_fs/ffs/file.rs
+++ b/src/fw_fs/ffs/file.rs
@@ -106,6 +106,7 @@ pub(crate) struct Header {
 // EFI_FFS_FILE_HEADER
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
 pub(crate) struct Header2 {
     pub(crate) header: Header,
     pub(crate) extended_size: u64,


### PR DESCRIPTION
## Description

* Cargo.toml:
  * Add nightly feature to supress unexpected_cfgs warning
* change 'default_features' to 'default-features' as the new convention is required for Rust 2024 edition
* files.rs:
  * Add allow(dead_code) for the Header2 struct to supress dead_code warning.

For details on how to complete to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

* All warnings were properly supressed.
* Verified these changes are compatibley with Rust toolchain 1.76.

## Integration Instructions
N/A