### PR TITLE
Adds a test for SectionMetadata parsing and fixes an issue with GUID_DEFINED section parsing.

### DIFF
--- a/src/fw_fs.rs
+++ b/src/fw_fs.rs
@@ -679,7 +679,7 @@ impl Section {
                 (SectionMetaData::Compression(*compression_header), data)
             }
             FfsSectionRawType::encapsulated::GUID_DEFINED => {
-                let guid_defined_header_size = mem::size_of::<section::header::Compression>();
+                let guid_defined_header_size = mem::size_of::<section::header::GuidDefined>();
                 //verify that buffer has enough storage for a guid_defined header.
                 if buffer.len() < content_offset + guid_defined_header_size {
                     Err(efi::Status::VOLUME_CORRUPTED)?;

--- a/src/fw_fs/ffs/section.rs
+++ b/src/fw_fs/ffs/section.rs
@@ -101,6 +101,8 @@ pub mod header {
         pub uncompressed_length: u32,
         pub compression_type: u8,
     }
+    pub const NOT_COMPRESSED: u8 = 0x00;
+    pub const STANDARD_COMPRESSION: u8 = 0x01;
 
     /// EFI_GUID_DEFINED_SECTION per PI spec 1.8A 3.2.5.7
     #[repr(C)]


### PR DESCRIPTION
## Description

* Add a test for section metadata correctness
* fix a bug in GUID_DEFINED section parsing.

- [x] Impacts functionality?
  - bugfix
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Added unit test to verify SectionMetadata correctness.

## Integration Instructions

N/A
