### PR TITLE
fw_fs: new_from_address: add validation of firmware volume header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mu_pi"
-version = "5.0.0"
+version = "5.0.1"
 edition = "2021"
 license = "BSD-2-Clause-Patent"
 description = "Platform Initialization (PI) Specification definitions and support code in Rust."


### PR DESCRIPTION

## Description

Validate the firmware volume header by checking the signature, before the call to `core::slice::from_raw_parts`. This is because if the passed address is not a firmware volume, the call to `from_raw_parts` could panic, instead of catching the failure later and cleanly returning an error.

This validation typically takes place in the `new` function. It will continue to take place there, but it also needs to be validated here to prevent a panic with the `from_raw_parts` call.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Failing tests now pass

## Integration Instructions

N/A
