### PR TITLE
Add spec protocol definitions for Security and Security2 Protocols as defined in PI spec

### DIFF
--- a/src/protocols.rs
+++ b/src/protocols.rs
@@ -16,6 +16,7 @@ pub mod firmware_volume_block;
 pub mod metronome;
 pub mod runtime;
 pub mod security;
+pub mod security2;
 pub mod status_code;
 pub mod timer;
 pub mod watchdog;

--- a/src/protocols.rs
+++ b/src/protocols.rs
@@ -15,6 +15,7 @@ pub mod firmware_volume;
 pub mod firmware_volume_block;
 pub mod metronome;
 pub mod runtime;
+pub mod security;
 pub mod status_code;
 pub mod timer;
 pub mod watchdog;

--- a/src/protocols/security.rs
+++ b/src/protocols/security.rs
@@ -1,0 +1,76 @@
+//! Security Architectural Protocol
+//!
+//! Security Architectural Protocol:
+//! Abstracts security-specific functions from the DXE Foundation for purposes of handling GUIDed section
+//! encapsulations. This protocol must be produced by a boot service or runtime DXE driver and may only be consumed by
+//! the DXE Foundation and any other DXE drivers that need to validate the authentication of files.
+//!
+//! See <https://uefi.org/specs/PI/1.8A/V2_DXE_Architectural_Protocols.html#efi-security-arch-protocol>
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+use r_efi::efi;
+
+pub const PROTOCOL_GUID: efi::Guid =
+    efi::Guid::from_fields(0xA46423E3, 0x4617, 0x49f1, 0xB9, 0xFF, &[0xD1, 0xBF, 0xA9, 0x11, 0x58, 0x39]);
+
+/// The EFI_SECURITY_ARCH_PROTOCOL (SAP) is used to abstract platform-specific
+/// policy from the DXE core response to an attempt to use a file that returns a
+/// given status for the authentication check from the section extraction protocol.
+///
+/// The possible responses in a given SAP implementation may include locking
+/// flash upon failure to authenticate, attestation logging for all signed drivers,
+/// and other exception operations.  The File parameter allows for possible logging
+/// within the SAP of the driver.
+///
+/// If File is NULL, then EFI_INVALID_PARAMETER is returned.
+///
+/// If the file specified by File with an authentication status specified by
+/// AuthenticationStatus is safe for the DXE Core to use, then EFI_SUCCESS is returned.
+///
+/// If the file specified by File with an authentication status specified by
+/// AuthenticationStatus is not safe for the DXE Core to use under any circumstances,
+/// then EFI_ACCESS_DENIED is returned.
+///
+/// If the file specified by File with an authentication status specified by
+/// AuthenticationStatus is not safe for the DXE Core to use right now, but it
+/// might be possible to use it at a future time, then EFI_SECURITY_VIOLATION is
+/// returned.
+///
+/// @param  this             The EFI_SECURITY_ARCH_PROTOCOL instance.
+/// @param  authentication_status
+///                          This is the authentication type returned from the Section
+///                          Extraction protocol. See the Section Extraction Protocol
+///                          Specification for details on this type.
+/// @param  file             This is a pointer to the device path of the file that is
+///                          being dispatched. This will optionally be used for logging.
+///
+/// @retval Status::SUCCESS            The file specified by File did authenticate, and the
+///                                    platform policy dictates that the DXE Core may use File.
+/// @retval Status::INVALID_PARAMETER  Driver is NULL.
+/// @retval Status::SECURITY_VIOLATION The file specified by File did not authenticate, and
+///                                    the platform policy dictates that File should be placed
+///                                    in the untrusted state. A file may be promoted from
+///                                    the untrusted to the trusted state at a future time
+///                                    with a call to the Trust() DXE Service.
+/// @retval Status::ACCESS_DENIED      The file specified by File did not authenticate, and
+///                                    the platform policy dictates that File should not be
+///                                    used for any purpose.
+pub type EfiSecurityFileAuthenticationState = extern "efiapi" fn(
+    this: *mut Protocol,
+    authentication_status: u32,
+    file: *mut efi::protocols::device_path::Protocol,
+) -> efi::Status;
+
+/// The EFI_SECURITY_ARCH_PROTOCOL is used to abstract platform-specific policy
+/// from the DXE core.  This includes locking flash upon failure to authenticate,
+/// attestation logging, and other exception operations.
+#[repr(C)]
+pub struct Protocol {
+    pub file_authentication_state: EfiSecurityFileAuthenticationState,
+}

--- a/src/protocols/security2.rs
+++ b/src/protocols/security2.rs
@@ -1,0 +1,91 @@
+//! Security2 Architectural Protocol
+//!
+//! Abstracts security-specific functions from the DXE Foundation of UEFI Image Verification, Trusted Computing Group
+//! (TCG) measured boot, and User Identity policy for image loading and consoles. This protocol must be produced by a
+//! boot service or runtime DXE driver.
+//!
+//! This protocol is optional and must be published prior to the EFI_SECURITY_ARCH_PROTOCOL. As a result, the same
+//! driver must publish both of these interfaces.
+//!
+//! When both Security and Security2 Architectural Protocols are published, LoadImage must use them in accordance with
+//! the following rules:
+//! - The Security2 protocol must be used on every image being loaded.
+//! - The Security protocol must be used after the Security2 protocol and only on images that have been read using
+//!   Firmware Volume protocol.
+//! - When only Security architectural protocol is published, LoadImage must use it on every image being loaded.
+//!
+//! See <https://uefi.org/specs/PI/1.8A/V2_DXE_Architectural_Protocols.html#security2-architectural-protocol>
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+use core::ffi::c_void;
+
+use r_efi::efi;
+
+pub const PROTOCOL_GUID: efi::Guid =
+    efi::Guid::from_fields(0x94ab2f58, 0x1438, 0x4ef1, 0x91, 0x52, &[0x18, 0x94, 0x1a, 0x3a, 0x0e, 0x68]);
+
+/// The DXE Foundation uses this service to measure and/or verify a UEFI image.
+///
+/// This service abstracts the invocation of Trusted Computing Group (TCG) measured boot, UEFI
+/// Secure boot, and UEFI User Identity infrastructure. For the former two, the DXE Foundation
+/// invokes the FileAuthentication() with a DevicePath and corresponding image in
+/// FileBuffer memory. The TCG measurement code will record the FileBuffer contents into the
+/// appropriate PCR. The image verification logic will confirm the integrity and provenance of the
+/// image in FileBuffer of length FileSize . The origin of the image will be DevicePath in
+/// these cases.
+/// If the FileBuffer is NULL, the interface will determine if the DevicePath can be connected
+/// in order to support the User Identification policy.
+///
+/// @param  this             The EFI_SECURITY2_ARCH_PROTOCOL instance.
+/// @param  file             A pointer to the device path of the file that is
+///                          being dispatched. This will optionally be used for logging.
+/// @param  file_buffer      A pointer to the buffer with the UEFI file image.
+/// @param  file_size        The size of the file.
+/// @param  boot_policy      A boot policy that was used to call LoadImage() UEFI service. If
+///                          FileAuthentication() is invoked not from the LoadImage(),
+///                          BootPolicy must be set to FALSE.
+///
+/// @retval Status::SUCCESS         The file specified by DevicePath and non-NULL
+///                                 FileBuffer did authenticate, and the platform policy dictates
+///                                 that the DXE Foundation may use the file.
+/// @retval Status::SUCCESS         The device path specified by NULL device path DevicePath
+///                                 and non-NULL FileBuffer did authenticate, and the platform
+///                                 policy dictates that the DXE Foundation may execute the image in
+///                                 FileBuffer.
+/// @retval Status::SUCCESS         FileBuffer is NULL and current user has permission to start
+///                                 UEFI device drivers on the device path specified by DevicePath.
+/// @retval Status::SECURITY_VIOLATION  The file specified by DevicePath and FileBuffer did not
+///                                     authenticate, and the platform policy dictates that the file should be
+///                                     placed in the untrusted state. The image has been added to the file
+///                                     execution table.
+/// @retval Status::ACCESS_DENIED       The file specified by File and FileBuffer did not
+///                                     authenticate, and the platform policy dictates that the DXE
+///                                     Foundation may not use File.
+/// @retval Status::SECURITY_VIOLATION  FileBuffer is NULL and the user has no
+///                                     permission to start UEFI device drivers on the device path specified
+///                                     by DevicePath.
+/// @retval Status::SECURITY_VIOLATION  FileBuffer is not NULL and the user has no permission to load
+///                                     drivers from the device path specified by DevicePath. The
+///                                     image has been added into the list of the deferred images.
+pub type EfiSecurity2FileAuthentication = extern "efiapi" fn(
+    this: *mut Protocol,
+    file: *mut efi::protocols::device_path::Protocol,
+    file_buffer: *mut c_void,
+    file_size: usize,
+    boot_policy: bool,
+) -> efi::Status;
+
+/// The EFI_SECURITY2_ARCH_PROTOCOL is used to abstract platform-specific policy from the
+/// DXE Foundation. This includes measuring the PE/COFF image prior to invoking, comparing the
+/// image against a policy (whether a white-list/black-list of public image verification keys
+/// or registered hashes).
+#[repr(C)]
+pub struct Protocol {
+    pub file_authentication: EfiSecurity2FileAuthentication,
+}


### PR DESCRIPTION
## Description

Add support for spec protocol definitions for Security and Security2 Architectural protocols as described in section 12.9 of the PI specification (https://uefi.org/specs/PI/1.8A/V2_DXE_Architectural_Protocols.html#security-architectural-protocols)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

Confirmed that the defined structures build.

## Integration Instructions

N/A
