### PR TITLE
Use r-efi definition for EfiSystemContext per the PI spec

### DIFF
--- a/src/protocols/cpu_arch.rs
+++ b/src/protocols/cpu_arch.rs
@@ -11,8 +11,6 @@
 //! SPDX-License-Identifier: BSD-2-Clause-Patent
 //!
 
-use core::ffi::c_void;
-
 use r_efi::efi;
 
 /// CPU Architectrural Protocol GUID
@@ -74,7 +72,7 @@ pub type EfiExceptionType = isize;
 ///
 /// # Documentation
 /// UEFI Specification version 2.10, Section 18.2.4
-pub type EfiSystemContext = *mut c_void;
+pub type EfiSystemContext = efi::protocols::debug_support::SystemContext;
 
 /// Function type definition for interrupt handler.
 ///


### PR DESCRIPTION
## Description

Switches from using a cvoid to using the `EFI_SYSTEM_CONTEXT` from the `EFI_DEBUG_SUPPORT_PROTOCOL` defined in r-efi. This is the definition specified in the PI spec.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
