### PR TITLE
hob: Make HobList::new() const

### DIFF
--- a/src/hob.rs
+++ b/src/hob.rs
@@ -721,7 +721,7 @@ pub unsafe fn get_c_hob_list_size(hob_list: *const c_void) -> usize {
 
 impl<'a> HobList<'a> {
     /// Instantiates a Hoblist.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         HobList(Vec::new())
     }
 


### PR DESCRIPTION
## Description

HobList is just a wrapper around a Vec<Hob>. Since Vec::new() is const, HobList::new() can be const as well, allowing for an empty HobList to be present in a struct that exists before allocations are available.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This continues to compile.

## Integration Instructions

N/A
