### PR TITLE
Adding resource descriptor hob type 2

### DIFF
--- a/src/hob.rs
+++ b/src/hob.rs
@@ -455,6 +455,10 @@ impl ResourceDescriptor {
     }
 }
 
+/// PI Spec Status: Pending.
+/// This change is checked in as a code first approach. The PI spec will be updated
+/// to reflect this change in the future.
+///
 /// Describes the resource properties of all fixed,
 /// nonrelocatable resource ranges found on the processor
 /// host bus during the HOB producer phase.
@@ -467,7 +471,7 @@ pub struct ResourceDescriptorV2 {
     ///
     pub v1: ResourceDescriptor,
 
-    /// The number of bytes of the resource region.
+    /// The attributes of the resource described by this HOB.
     ///
     pub attributes: u64,
 }

--- a/src/hob.rs
+++ b/src/hob.rs
@@ -1493,6 +1493,7 @@ mod tests {
     fn gen_resource_descriptor_v2() -> hob::ResourceDescriptorV2 {
         let mut v1 = gen_resource_descriptor();
         v1.header.r#type = hob::RESOURCE_DESCRIPTOR2;
+        v1.header.length = size_of::<hob::ResourceDescriptorV2>() as u16;
 
         hob::ResourceDescriptorV2 { v1: v1, attributes: 8 }
     }
@@ -1851,6 +1852,10 @@ mod tests {
                 Hob::Handoff(handoff) => {
                     assert_eq!(handoff.memory_top, 0xdeadbeef);
                 }
+                Hob::ResourceDescriptorV2(resource) => {
+                    assert_eq!(resource.v1.header.r#type, hob::RESOURCE_DESCRIPTOR2);
+                    assert_eq!(resource.v1.resource_type, hob::EFI_RESOURCE_SYSTEM_MEMORY);
+                }
                 Hob::Cpu(cpu) => {
                     assert_eq!(cpu.size_of_memory_space, 0);
                 }
@@ -1861,7 +1866,7 @@ mod tests {
             count += 1;
         });
 
-        assert_eq!(count, 11);
+        assert_eq!(count, 12);
 
         // free the c array
         manually_free_c_array(c_array_hoblist, length);

--- a/src/hob.rs
+++ b/src/hob.rs
@@ -1289,7 +1289,7 @@ impl fmt::Debug for HobList<'_> {
                           Resource Attribute Type: 0x{:x}
                           Resource Start Address: 0x{:x}
                           Resource Length: 0x{:x}
-                          Attibutes: 0x{:x}\n"},
+                          Attributes: 0x{:x}\n"},
                         hob.v1.header.length,
                         hob.v1.resource_type,
                         hob.v1.resource_attribute,
@@ -1486,7 +1486,7 @@ mod tests {
     // Generate a test resource descriptor hob
     // # Returns
     // A ResourceDescriptor hob
-    fn gen_resource_descriptorv2() -> hob::ResourceDescriptorV2 {
+    fn gen_resource_descriptor_v2() -> hob::ResourceDescriptorV2 {
         let mut v1 = gen_resource_descriptor();
         v1.header.r#type = hob::RESOURCE_DESCRIPTOR2;
 
@@ -1654,6 +1654,11 @@ mod tests {
         hoblist.push(Hob::FirmwareVolume(&firmware_volume));
 
         assert_eq!(hoblist.len(), 2);
+
+        let resource_v2 = gen_resource_descriptor_v2();
+        hoblist.push(Hob::ResourceDescriptorV2(&resource_v2));
+
+        assert_eq!(hoblist.len(), 3);
     }
 
     #[test]
@@ -1732,6 +1737,7 @@ mod tests {
         let memory_allocation = gen_memory_allocation();
         let memory_allocation_module = gen_memory_allocation_module();
         let cpu = gen_cpu();
+        let resource_v2 = gen_resource_descriptor_v2();
         let end_of_hob_list = gen_end_of_hoblist();
 
         // create a new hoblist
@@ -1748,6 +1754,7 @@ mod tests {
         hoblist.push(Hob::MemoryAllocation(&memory_allocation));
         hoblist.push(Hob::MemoryAllocationModule(&memory_allocation_module));
         hoblist.push(Hob::Cpu(&cpu));
+        hoblist.push(Hob::ResourceDescriptorV2(&resource_v2));
         hoblist.push(Hob::Handoff(&end_of_hob_list));
 
         // assert that the hoblist has 3 hobs and they are of the correct type
@@ -1785,6 +1792,10 @@ mod tests {
                 }
                 Hob::Cpu(cpu) => {
                     assert_eq!(cpu.size_of_memory_space, 0);
+                }
+                Hob::ResourceDescriptorV2(resource) => {
+                    assert_eq!(resource.v1.header.r#type, hob::RESOURCE_DESCRIPTOR2);
+                    assert_eq!(resource.v1.resource_type, hob::EFI_RESOURCE_SYSTEM_MEMORY);
                 }
                 _ => {
                     panic!("Unexpected hob type");
@@ -1907,6 +1918,7 @@ mod tests {
         let memory_allocation = gen_memory_allocation();
         let memory_allocation_module = gen_memory_allocation_module();
         let cpu = gen_cpu();
+        let resource_v2 = gen_resource_descriptor_v2();
         let end_of_hob_list = gen_end_of_hoblist();
 
         // create a new hoblist
@@ -1923,6 +1935,7 @@ mod tests {
         hoblist.push(Hob::MemoryAllocation(&memory_allocation));
         hoblist.push(Hob::MemoryAllocationModule(&memory_allocation_module));
         hoblist.push(Hob::Cpu(&cpu));
+        hoblist.push(Hob::ResourceDescriptorV2(&resource_v2));
         hoblist.push(Hob::Handoff(&end_of_hob_list));
 
         // Make sure we can iterate over a reference to a HobList without

--- a/src/hob.rs
+++ b/src/hob.rs
@@ -1804,7 +1804,7 @@ mod tests {
             count += 1;
         });
 
-        assert_eq!(count, 11);
+        assert_eq!(count, 12);
 
         // c_hoblist is a pointer to the hoblist - we need to manually free it later
         let (c_array_hoblist, length) = to_c_array(&hoblist);

--- a/src/hob.rs
+++ b/src/hob.rs
@@ -475,10 +475,7 @@ pub struct ResourceDescriptorV2 {
 impl From<ResourceDescriptor> for ResourceDescriptorV2 {
     fn from(mut v1: ResourceDescriptor) -> Self {
         v1.header.r#type = RESOURCE_DESCRIPTOR2;
-        ResourceDescriptorV2 {
-            v1: v1,
-            attributes: 0,
-        }
+        ResourceDescriptorV2 { v1: v1, attributes: 0 }
     }
 }
 
@@ -1493,10 +1490,7 @@ mod tests {
         let mut v1 = gen_resource_descriptor();
         v1.header.r#type = hob::RESOURCE_DESCRIPTOR2;
 
-        hob::ResourceDescriptorV2 {
-            v1: v1,
-            attributes: 8
-        }
+        hob::ResourceDescriptorV2 { v1: v1, attributes: 8 }
     }
 
     // Generate a test phase handoff information table hob


### PR DESCRIPTION
## Description

This change adds the implementation of supporting "resource descriptor hob type 2", which will extends the existing definition of resource descriptor hob with an attribute field.

This field can be used to provide the actual attributes needs to be set for the memory region, instead of relying on the state of the system.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on QEMU SBSA and Q35, both booted to Windows.

## Integration Instructions

N/A