### PR TITLE
Fix GuidHob bug and rework relocate_hobs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mu_pi"
-version = "5.2.0"
+version = "5.2.1"
 edition = "2021"
 license = "BSD-2-Clause-Patent"
 description = "Platform Initialization (PI) Specification definitions and support code in Rust."

--- a/src/hob.rs
+++ b/src/hob.rs
@@ -1027,114 +1027,25 @@ impl<'a> HobList<'a> {
     /// }
     /// ```
     pub fn relocate_hobs(&mut self) {
-        let mut new_hobs = Vec::new();
-        for hob in self.0.iter() {
-            let new_hob = match hob {
-                Hob::Handoff(hob) => {
-                    let new_hob = Box::new(PhaseHandoffInformationTable {
-                        header: hob.header,
-                        version: hob.version,
-                        boot_mode: hob.boot_mode,
-                        memory_top: hob.memory_top,
-                        memory_bottom: hob.memory_bottom,
-                        free_memory_top: hob.free_memory_top,
-                        free_memory_bottom: hob.free_memory_bottom,
-                        end_of_hob_list: hob.end_of_hob_list,
-                    });
-                    Hob::Handoff(Box::leak(new_hob))
-                }
-                Hob::MemoryAllocation(hob) => {
-                    let new_hob =
-                        Box::new(MemoryAllocation { header: hob.header, alloc_descriptor: hob.alloc_descriptor });
-                    Hob::MemoryAllocation(Box::leak(new_hob))
-                }
-                Hob::MemoryAllocationModule(hob) => {
-                    let new_hob = Box::new(MemoryAllocationModule {
-                        header: hob.header,
-                        alloc_descriptor: hob.alloc_descriptor,
-                        module_name: hob.module_name,
-                        entry_point: hob.entry_point,
-                    });
-                    Hob::MemoryAllocationModule(Box::leak(new_hob))
-                }
-                Hob::Capsule(hob) => {
-                    let new_hob =
-                        Box::new(Capsule { header: hob.header, base_address: hob.base_address, length: hob.length });
-                    Hob::Capsule(Box::leak(new_hob))
-                }
-                Hob::ResourceDescriptor(hob) => {
-                    let new_hob = Box::new(ResourceDescriptor {
-                        header: hob.header,
-                        owner: hob.owner,
-                        resource_type: hob.resource_type,
-                        resource_attribute: hob.resource_attribute,
-                        physical_start: hob.physical_start,
-                        resource_length: hob.resource_length,
-                    });
-                    Hob::ResourceDescriptor(Box::leak(new_hob))
-                }
+        for hob in self.0.iter_mut() {
+            match hob {
+                Hob::Handoff(hob) => *hob = Box::leak(Box::new(PhaseHandoffInformationTable::clone(hob))),
+                Hob::MemoryAllocation(hob) => *hob = Box::leak(Box::new(MemoryAllocation::clone(hob))),
+                Hob::MemoryAllocationModule(hob) => *hob = Box::leak(Box::new(MemoryAllocationModule::clone(hob))),
+                Hob::Capsule(hob) => *hob = Box::leak(Box::new(Capsule::clone(hob))),
+                Hob::ResourceDescriptor(hob) => *hob = Box::leak(Box::new(ResourceDescriptor::clone(hob))),
                 Hob::GuidHob(hob, data) => {
-                    let new_hob = Box::new(GuidHob { header: hob.header, name: hob.name });
-                    Hob::GuidHob(Box::leak(new_hob), data)
+                    *hob = Box::leak(Box::new(GuidHob::clone(hob)));
+                    *data = Vec::leak(Vec::from(*data));
                 }
-                Hob::FirmwareVolume(hob) => {
-                    let new_hob = Box::new(FirmwareVolume {
-                        header: hob.header,
-                        base_address: hob.base_address,
-                        length: hob.length,
-                    });
-                    Hob::FirmwareVolume(Box::leak(new_hob))
-                }
-                Hob::FirmwareVolume2(hob) => {
-                    let new_hob = Box::new(FirmwareVolume2 {
-                        header: hob.header,
-                        base_address: hob.base_address,
-                        length: hob.length,
-                        fv_name: hob.fv_name,
-                        file_name: hob.file_name,
-                    });
-                    Hob::FirmwareVolume2(Box::leak(new_hob))
-                }
-                Hob::FirmwareVolume3(hob) => {
-                    let new_hob = Box::new(FirmwareVolume3 {
-                        header: hob.header,
-                        base_address: hob.base_address,
-                        length: hob.length,
-                        authentication_status: hob.authentication_status,
-                        extracted_fv: hob.extracted_fv,
-                        fv_name: hob.fv_name,
-                        file_name: hob.file_name,
-                    });
-                    Hob::FirmwareVolume3(Box::leak(new_hob))
-                }
-                Hob::Cpu(hob) => {
-                    let new_hob = Box::new(Cpu {
-                        header: hob.header,
-                        size_of_memory_space: hob.size_of_memory_space,
-                        size_of_io_space: hob.size_of_io_space,
-                        reserved: hob.reserved,
-                    });
-                    Hob::Cpu(Box::leak(new_hob))
-                }
-                Hob::ResourceDescriptorV2(hob) => {
-                    let new_hob = Box::new(ResourceDescriptorV2 {
-                        v1: ResourceDescriptor {
-                            header: hob.v1.header,
-                            owner: hob.v1.owner,
-                            resource_type: hob.v1.resource_type,
-                            resource_attribute: hob.v1.resource_attribute,
-                            physical_start: hob.v1.physical_start,
-                            resource_length: hob.v1.resource_length,
-                        },
-                        attributes: hob.attributes,
-                    });
-                    Hob::ResourceDescriptorV2(Box::leak(new_hob))
-                }
-                Hob::Misc(hob_type) => Hob::Misc(*hob_type),
+                Hob::FirmwareVolume(hob) => *hob = Box::leak(Box::new(FirmwareVolume::clone(hob))),
+                Hob::FirmwareVolume2(hob) => *hob = Box::leak(Box::new(FirmwareVolume2::clone(hob))),
+                Hob::FirmwareVolume3(hob) => *hob = Box::leak(Box::new(FirmwareVolume3::clone(hob))),
+                Hob::Cpu(hob) => *hob = Box::leak(Box::new(Cpu::clone(hob))),
+                Hob::ResourceDescriptorV2(hob) => *hob = Box::leak(Box::new(ResourceDescriptorV2::clone(hob))),
+                Hob::Misc(hob_type) => *hob_type = *hob_type,
             };
-            new_hobs.push(new_hob);
         }
-        self.0 = new_hobs;
     }
 }
 

--- a/src/hob.rs
+++ b/src/hob.rs
@@ -125,7 +125,7 @@ pub mod header {
     /// All HOBs must contain this generic HOB header (EFI_HOB_GENERIC_HEADER).
     ///
     #[repr(C)]
-    #[derive(Copy, Clone, Debug)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct Hob {
         // EFI_HOB_GENERIC_HEADER
         /// Identifies the HOB data structure type.
@@ -146,7 +146,7 @@ pub mod header {
     /// subsequent inclusion in the UEFI memory map.
     ///
     #[repr(C)]
-    #[derive(Copy, Clone, Debug)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct MemoryAllocation {
         // EFI_HOB_MEMORY_ALLOCATION_HEADER
         /// A GUID that defines the memory allocation region's type and purpose, as well as
@@ -189,7 +189,7 @@ pub type MemoryPool = header::Hob;
 /// This HOB must be the first one in the HOB list.
 ///
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct PhaseHandoffInformationTable {
     /// The HOB generic header. Header.HobType = EFI_HOB_TYPE_HANDOFF.
     ///
@@ -267,7 +267,7 @@ pub type MemoryAllocationBspStore = MemoryAllocation;
 /// Defines the location and entry point of the HOB consumer phase.
 ///
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct MemoryAllocationModule {
     /// The HOB generic header. Header.HobType = EFI_HOB_TYPE_MEMORY_ALLOCATION.
     ///
@@ -411,7 +411,7 @@ pub const EFI_MEMORY_MORE_RELIABLE: u64 = 0x0000_0000_0001_0000;
 /// host bus during the HOB producer phase.
 ///
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct ResourceDescriptor {
     // EFI_HOB_RESOURCE_DESCRIPTOR
     /// The HOB generic header. Header.HobType = EFI_HOB_TYPE_RESOURCE_DESCRIPTOR.
@@ -464,7 +464,7 @@ impl ResourceDescriptor {
 /// host bus during the HOB producer phase.
 ///
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct ResourceDescriptorV2 {
     // EFI_HOB_RESOURCE_DESCRIPTOR
     /// The HOB generic header. Header.HobType = EFI_HOB_TYPE_RESOURCE_DESCRIPTOR.
@@ -504,7 +504,7 @@ pub struct GuidHob {
 /// Details the location of firmware volumes that contain firmware files.
 ///
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct FirmwareVolume {
     // EFI_HOB_FIRMWARE_VOLUME
     /// The HOB generic header. Header.HobType = EFI_HOB_TYPE_FV.
@@ -524,7 +524,7 @@ pub struct FirmwareVolume {
 /// from a file within another firmware volume.
 ///
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct FirmwareVolume2 {
     // EFI_HOB_FIRMWARE_VOLUME2
     /// The HOB generic header. Header.HobType = EFI_HOB_TYPE_FV2.
@@ -552,7 +552,7 @@ pub struct FirmwareVolume2 {
 /// from a file within another firmware volume.
 ///
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct FirmwareVolume3 {
     // EFI_HOB_FIRMWARE_VOLUME3
     /// The HOB generic header. Header.HobType = EFI_HOB_TYPE_FV3.
@@ -590,7 +590,7 @@ pub struct FirmwareVolume3 {
 /// Describes processor information, such as address space and I/O space capabilities.
 ///
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Cpu {
     // EFI_HOB_CPU
     /// The HOB generic header. Header.HobType = EFI_HOB_TYPE_CPU.
@@ -617,7 +617,7 @@ pub struct Cpu {
 /// CAPSULE_FLAGS_POPULATE_SYSTEM_TABLE flag set in the EFI_CAPSULE_HEADER.
 ///
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Capsule {
     // EFI_HOB_CAPSULE
     /// The HOB generic header where Header.HobType = EFI_HOB_TYPE_UEFI_CAPSULE.
@@ -1036,14 +1036,14 @@ impl<'a> HobList<'a> {
                 Hob::ResourceDescriptor(hob) => *hob = Box::leak(Box::new(ResourceDescriptor::clone(hob))),
                 Hob::GuidHob(hob, data) => {
                     *hob = Box::leak(Box::new(GuidHob::clone(hob)));
-                    *data = Vec::leak(Vec::from(*data));
+                    *data = Box::leak(data.to_vec().into_boxed_slice());
                 }
                 Hob::FirmwareVolume(hob) => *hob = Box::leak(Box::new(FirmwareVolume::clone(hob))),
                 Hob::FirmwareVolume2(hob) => *hob = Box::leak(Box::new(FirmwareVolume2::clone(hob))),
                 Hob::FirmwareVolume3(hob) => *hob = Box::leak(Box::new(FirmwareVolume3::clone(hob))),
                 Hob::Cpu(hob) => *hob = Box::leak(Box::new(Cpu::clone(hob))),
                 Hob::ResourceDescriptorV2(hob) => *hob = Box::leak(Box::new(ResourceDescriptorV2::clone(hob))),
-                Hob::Misc(hob_type) => *hob_type = *hob_type,
+                Hob::Misc(_) => (), // Data is owned in Misc (nothing to move),
             };
         }
     }
@@ -1328,6 +1328,7 @@ mod tests {
     use core::{
         ffi::c_void,
         mem::{drop, forget, size_of},
+        ptr,
         slice::from_raw_parts,
     };
 
@@ -1460,11 +1461,19 @@ mod tests {
         hob::Capsule { header, base_address: 0, length: 0x12 }
     }
 
-    fn gen_guid_hob() -> hob::GuidHob {
-        let header =
-            hob::header::Hob { r#type: hob::GUID_EXTENSION, length: size_of::<hob::GuidHob>() as u16, reserved: 0 };
-
-        hob::GuidHob { header, name: r_efi::efi::Guid::from_fields(1, 2, 3, 4, 5, &[6, 7, 8, 9, 10, 11]) }
+    fn gen_guid_hob() -> (hob::GuidHob, Box<[u8]>) {
+        let data = Box::new([1_u8, 2, 3, 4, 5, 6, 7, 8]);
+        (
+            hob::GuidHob {
+                header: hob::header::Hob {
+                    r#type: hob::GUID_EXTENSION,
+                    length: (size_of::<hob::GuidHob>() + data.len()) as u16,
+                    reserved: 0,
+                },
+                name: r_efi::efi::Guid::from_fields(1, 2, 3, 4, 5, &[6, 7, 8, 9, 10, 11]),
+            },
+            data,
+        )
     }
 
     fn gen_phase_handoff_information_table() -> hob::PhaseHandoffInformationTable {
@@ -1586,7 +1595,7 @@ mod tests {
         let firmware_volume3 = gen_firmware_volume3();
         let end_of_hob_list = gen_end_of_hoblist();
         let capsule = gen_capsule();
-        let guid_hob = gen_guid_hob();
+        let (guid_hob, guid_hob_data) = gen_guid_hob();
         let memory_allocation = gen_memory_allocation();
         let memory_allocation_module = gen_memory_allocation_module();
 
@@ -1595,7 +1604,7 @@ mod tests {
         hoblist.push(Hob::FirmwareVolume2(&firmware_volume2));
         hoblist.push(Hob::FirmwareVolume3(&firmware_volume3));
         hoblist.push(Hob::Capsule(&capsule));
-        hoblist.push(Hob::GuidHob(&guid_hob, &[0u8; 0]));
+        hoblist.push(Hob::GuidHob(&guid_hob, guid_hob_data.as_ref()));
         hoblist.push(Hob::MemoryAllocation(&memory_allocation));
         hoblist.push(Hob::MemoryAllocationModule(&memory_allocation_module));
         hoblist.push(Hob::Handoff(&end_of_hob_list));
@@ -1617,7 +1626,7 @@ mod tests {
                 }
                 Hob::GuidHob(guid_hob, data) => {
                     assert_eq!(guid_hob.name, r_efi::efi::Guid::from_fields(1, 2, 3, 4, 5, &[6, 7, 8, 9, 10, 11]));
-                    assert_eq!(*data, [0u8; 0]);
+                    assert_eq!(*data, &[1_u8, 2, 3, 4, 5, 6, 7, 8]);
                 }
                 Hob::FirmwareVolume(firmware_volume) => {
                     assert_eq!(firmware_volume.length, 0x0123456789abcdef);
@@ -1649,7 +1658,7 @@ mod tests {
         let firmware_volume2 = gen_firmware_volume2();
         let firmware_volume3 = gen_firmware_volume3();
         let capsule = gen_capsule();
-        let guid_hob = gen_guid_hob();
+        let (guid_hob, guid_hob_data) = gen_guid_hob();
         let memory_allocation = gen_memory_allocation();
         let memory_allocation_module = gen_memory_allocation_module();
         let cpu = gen_cpu();
@@ -1666,7 +1675,7 @@ mod tests {
         hoblist.push(Hob::FirmwareVolume2(&firmware_volume2));
         hoblist.push(Hob::FirmwareVolume3(&firmware_volume3));
         hoblist.push(Hob::Capsule(&capsule));
-        hoblist.push(Hob::GuidHob(&guid_hob, &[0u8; 0]));
+        hoblist.push(Hob::GuidHob(&guid_hob, guid_hob_data.as_ref()));
         hoblist.push(Hob::MemoryAllocation(&memory_allocation));
         hoblist.push(Hob::MemoryAllocationModule(&memory_allocation_module));
         hoblist.push(Hob::Cpu(&cpu));
@@ -1692,7 +1701,7 @@ mod tests {
                 }
                 Hob::GuidHob(guid_hob, data) => {
                     assert_eq!(guid_hob.name, r_efi::efi::Guid::from_fields(1, 2, 3, 4, 5, &[6, 7, 8, 9, 10, 11]));
-                    assert_eq!(*data, [0u8; 0]);
+                    assert_eq!(&data[..], &guid_hob_data[..]);
                 }
                 Hob::FirmwareVolume(firmware_volume) => {
                     assert_eq!(firmware_volume.length, 0x0123456789abcdef);
@@ -1749,7 +1758,7 @@ mod tests {
                 }
                 Hob::GuidHob(guid_hob, data) => {
                     assert_eq!(guid_hob.name, r_efi::efi::Guid::from_fields(1, 2, 3, 4, 5, &[6, 7, 8, 9, 10, 11]));
-                    assert_eq!(*data, [0u8; 0]);
+                    assert_eq!(&data[..], &[1_u8, 2, 3, 4, 5, 6, 7, 8]);
                 }
                 Hob::FirmwareVolume(firmware_volume) => {
                     assert_eq!(firmware_volume.length, 0x0123456789abcdef);
@@ -1792,7 +1801,7 @@ mod tests {
         let firmware_volume2 = gen_firmware_volume2();
         let firmware_volume3 = gen_firmware_volume3();
         let capsule = gen_capsule();
-        let guid_hob = gen_guid_hob();
+        let (guid_hob, guid_hob_data) = gen_guid_hob();
         let memory_allocation = gen_memory_allocation();
         let memory_allocation_module = gen_memory_allocation_module();
         let cpu = gen_cpu();
@@ -1808,7 +1817,7 @@ mod tests {
         hoblist.push(Hob::FirmwareVolume2(&firmware_volume2));
         hoblist.push(Hob::FirmwareVolume3(&firmware_volume3));
         hoblist.push(Hob::Capsule(&capsule));
-        hoblist.push(Hob::GuidHob(&guid_hob, &[0u8; 0]));
+        hoblist.push(Hob::GuidHob(&guid_hob, guid_hob_data.as_ref()));
         hoblist.push(Hob::MemoryAllocation(&memory_allocation));
         hoblist.push(Hob::MemoryAllocationModule(&memory_allocation_module));
         hoblist.push(Hob::Cpu(&cpu));
@@ -1834,7 +1843,7 @@ mod tests {
         let firmware_volume2 = gen_firmware_volume2();
         let firmware_volume3 = gen_firmware_volume3();
         let capsule = gen_capsule();
-        let guid_hob = gen_guid_hob();
+        let (guid_hob, guid_hob_data) = gen_guid_hob();
         let memory_allocation = gen_memory_allocation();
         let memory_allocation_module = gen_memory_allocation_module();
         let cpu = gen_cpu();
@@ -1851,7 +1860,7 @@ mod tests {
         hoblist.push(Hob::FirmwareVolume2(&firmware_volume2));
         hoblist.push(Hob::FirmwareVolume3(&firmware_volume3));
         hoblist.push(Hob::Capsule(&capsule));
-        hoblist.push(Hob::GuidHob(&guid_hob, &[0u8; 0]));
+        hoblist.push(Hob::GuidHob(&guid_hob, guid_hob_data.as_ref()));
         hoblist.push(Hob::MemoryAllocation(&memory_allocation));
         hoblist.push(Hob::MemoryAllocationModule(&memory_allocation_module));
         hoblist.push(Hob::Cpu(&cpu));
@@ -1866,6 +1875,112 @@ mod tests {
 
         for hob in hoblist {
             println!("{:?}", hob.header());
+        }
+    }
+
+    #[test]
+    fn test_relocate_hobs() {
+        // generate some test hobs
+        let resource = gen_resource_descriptor();
+        let handoff = gen_phase_handoff_information_table();
+        let firmware_volume = gen_firmware_volume();
+        let firmware_volume2 = gen_firmware_volume2();
+        let firmware_volume3 = gen_firmware_volume3();
+        let capsule = gen_capsule();
+        let (guid_hob, guid_hob_data) = gen_guid_hob();
+        let memory_allocation = gen_memory_allocation();
+        let memory_allocation_module = gen_memory_allocation_module();
+        let cpu = gen_cpu();
+        let resource_v2 = gen_resource_descriptor_v2();
+        let end_of_hob_list = gen_end_of_hoblist();
+
+        // create a new hoblist
+        let mut hoblist = HobList::new();
+
+        // Push the resource descriptor to the hoblist
+        hoblist.push(Hob::ResourceDescriptor(&resource));
+        hoblist.push(Hob::Handoff(&handoff));
+        hoblist.push(Hob::FirmwareVolume(&firmware_volume));
+        hoblist.push(Hob::FirmwareVolume2(&firmware_volume2));
+        hoblist.push(Hob::FirmwareVolume3(&firmware_volume3));
+        hoblist.push(Hob::Capsule(&capsule));
+        hoblist.push(Hob::GuidHob(&guid_hob, guid_hob_data.as_ref()));
+        hoblist.push(Hob::MemoryAllocation(&memory_allocation));
+        hoblist.push(Hob::MemoryAllocationModule(&memory_allocation_module));
+        hoblist.push(Hob::Cpu(&cpu));
+        hoblist.push(Hob::Misc(12345));
+        hoblist.push(Hob::ResourceDescriptorV2(&resource_v2));
+        hoblist.push(Hob::Handoff(&end_of_hob_list));
+
+        let hoblist_address = hoblist.as_mut_ptr::<()>() as usize;
+        let hoblist_len = hoblist.len();
+        hoblist.relocate_hobs();
+        assert_eq!(
+            hoblist_address,
+            hoblist.as_mut_ptr::<()>() as usize,
+            "Only hobs need to be relocated, not the vector."
+        );
+        assert_eq!(hoblist_len, hoblist.len());
+
+        for (i, hob) in hoblist.into_iter().enumerate() {
+            match hob {
+                Hob::ResourceDescriptor(hob) if i == 0 => {
+                    assert_ne!(ptr::addr_of!(resource), hob);
+                    assert_eq!(resource, *hob);
+                }
+                Hob::Handoff(hob) if i == 1 => {
+                    assert_ne!(ptr::addr_of!(handoff), hob);
+                    assert_eq!(handoff, *hob);
+                }
+                Hob::FirmwareVolume(hob) if i == 2 => {
+                    assert_ne!(ptr::addr_of!(firmware_volume), hob);
+                    assert_eq!(firmware_volume, *hob);
+                }
+                Hob::FirmwareVolume2(hob) if i == 3 => {
+                    assert_ne!(ptr::addr_of!(firmware_volume2), hob);
+                    assert_eq!(firmware_volume2, *hob);
+                }
+                Hob::FirmwareVolume3(hob) if i == 4 => {
+                    assert_ne!(ptr::addr_of!(firmware_volume3), hob);
+                    assert_eq!(firmware_volume3, *hob);
+                }
+                Hob::Capsule(hob) if i == 5 => {
+                    assert_ne!(ptr::addr_of!(capsule), hob);
+                    assert_eq!(capsule, *hob);
+                }
+                Hob::GuidHob(hob, hob_data) if i == 6 => {
+                    assert_ne!(ptr::addr_of!(guid_hob), hob);
+                    assert_ne!(guid_hob_data.as_ptr(), hob_data.as_ptr());
+                    assert_eq!(guid_hob.header, hob.header);
+                    assert_eq!(guid_hob.name, hob.name);
+                    assert_eq!(&guid_hob_data[..], &hob_data[..]);
+                }
+                Hob::MemoryAllocation(hob) if i == 7 => {
+                    assert_ne!(ptr::addr_of!(memory_allocation), hob);
+                    assert_eq!(memory_allocation.header, hob.header);
+                    assert_eq!(memory_allocation.alloc_descriptor, hob.alloc_descriptor);
+                }
+                Hob::MemoryAllocationModule(hob) if i == 8 => {
+                    assert_ne!(ptr::addr_of!(memory_allocation_module), hob);
+                    assert_eq!(memory_allocation_module, *hob);
+                }
+                Hob::Cpu(hob) if i == 9 => {
+                    assert_ne!(ptr::addr_of!(cpu), hob);
+                    assert_eq!(cpu, *hob);
+                }
+                Hob::Misc(hob) if i == 10 => {
+                    assert_eq!(12345, hob);
+                }
+                Hob::ResourceDescriptorV2(hob) if i == 11 => {
+                    assert_ne!(ptr::addr_of!(resource_v2), hob);
+                    assert_eq!(resource_v2, *hob);
+                }
+                Hob::Handoff(hob) if i == 12 => {
+                    assert_ne!(ptr::addr_of!(end_of_hob_list), hob);
+                    assert_eq!(end_of_hob_list, *hob);
+                }
+                _ => assert!(false, "Hob at index: {i}."),
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

- Fix GuidHob data not copied in new memory when relocating hobs. 
- Reusing the same array but only changing the reference to the hob in the array.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

I booted to shell in qemu with this version and the guid hobs that contain PEI records had data in them.

## Integration Instructions

N/A