### PR TITLE
hob: Do not run get_c_hob_list_size() example

### DIFF
--- a/src/hob.rs
+++ b/src/hob.rs
@@ -723,7 +723,7 @@ impl HobTrait for Hob<'_> {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// use mu_pi::hob::get_c_hob_list_size;
 /// use core::ffi::c_void;
 ///


### PR DESCRIPTION
## Description

This example makes assumptions that are not valid for actual execution as a doctest and it results in this hang when run:

"test src\hob.rs - hob::get_c_hob_list_size (line 726) has been running for over 60 seconds"

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- `cargo make test`

## Integration Instructions

N/A