### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Repo File Sync: .sync/rust_config/rustfmt.toml: Use Rust default of 4 space indentation
+f720cab38ad2e628c38f20d2e550346c872df58a


### PR DESCRIPTION
## Description

This file should only be used to ignore changes that are completely non-functional.

In this case, it is ignoring the commit that updated from 2 to 4 spaces.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

**Before:**

`> git blame -L 1079,1079 src/hob.rs`

```
f720cab3 (Project Mu UEFI Bot [bot] 2024-07-22 16:06:52 -0400 1079)         for hob in self.0.clone().into_iter() {
```

**After:**

`> git blame --ignore-revs-file .git-blame-ignore-revs -L 1079,1079 src/hob.rs`

```
830903d2 (Michael Kubacki 2024-06-04 09:05:10 +0000 1079)         for hob in self.0.clone().into_iter() {
```

## Integration Instructions

Set up your git config to you the ignore file if it is not already globally set to use files with the `.git-blame-ignore-revs` naming convention.