### PR TITLE
protocols: Add MM Communication protocols

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -33,6 +33,7 @@
     "fvmain",
     "GIGANTOR",
     "indoc",
+    "mmram",
     "oprom",
     "rebox",
     "rustc",

--- a/src/protocols.rs
+++ b/src/protocols.rs
@@ -10,6 +10,9 @@
 //!
 
 pub mod bds;
+pub mod communication;
+pub mod communication2;
+pub mod communication3;
 pub mod cpu_arch;
 pub mod firmware_volume;
 pub mod firmware_volume_block;

--- a/src/protocols/communication.rs
+++ b/src/protocols/communication.rs
@@ -1,0 +1,102 @@
+//! Communication Protocol
+//!
+//! Sends/receives a message for a registered handler.
+//!
+//! See <https://uefi.org/specs/PI/1.9/V4_UEFI_Protocols.html#efi-mm-communication-protocol>
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+use core::ffi::c_void;
+use r_efi::{efi, system};
+
+pub const PROTOCOL_GUID: efi::Guid =
+    efi::Guid::from_fields(0xc68ed8e2, 0x9dc6, 0x4cbd, 0x9d, 0x94, &[0xdb, 0x65, 0xac, 0xc5, 0xc3, 0x32]);
+
+pub const EFI_MM_INITIALIZATION_GUID: efi::Guid =
+    efi::Guid::from_fields(0x99be0d8f, 0x3548, 0x48aa, 0xb5, 0x77, &[0xfc, 0xfb, 0xa5, 0x6a, 0x67, 0xf7]);
+
+/// Sends/receives a message for a registered handler.
+///
+/// This protocol provides runtime services for communicating between DXE drivers and a registered MMI handler.
+///
+/// This function provides a service to send and receive messages from a registered UEFI service. The
+/// EFI_MM_COMMUNICATION_PROTOCOL driver is responsible for doing any of the copies such that the data lives in
+/// boot-service-accessible RAM.
+///
+/// A given implementation of the EFI_MM_COMMUNICATION_PROTOCOL may choose to use the EFI_MM_CONTROL_PROTOCOL for
+/// effecting the mode transition, or it may use some other method. The agent invoking the communication interface at
+/// runtime may be virtually mapped. The MM infrastructure code and handlers, on the other hand, execute in physical
+/// mode. As a result, the non- MM agent, which may be executing in the virtual-mode OS context as a result of an OS
+/// invocation of the UEFI SetVirtualAddressMap() service, should use a contiguous memory buffer with a physical
+/// address before invoking this service. If the virtual address of the buffer is used, the MM Driver may not know how
+/// to do the appropriate virtual-to-physical conversion.
+///
+/// To avoid confusion in interpreting frames, the CommunicateBuffer parameter should always begin with
+/// EFI_MM_COMMUNICATE_HEADER , which is defined in “Related Definitions” below. The header data is mandatory for
+/// messages sent into the MM agent.
+///
+/// If the CommSize parameter is omitted the MessageLength field in the EFI_MM_COMMUNICATE_HEADER , in conjunction
+/// with the size of the header itself, can be used to ascertain the total size of the communication payload. If the
+/// MessageLength is zero, or too large for the MM implementation to manage, the MM implementation must update the
+/// MessageLength to reflect the size of the Data buffer that it can tolerate.
+///
+/// If the CommSize parameter is passed into the call, but the integer it points to, has a value of 0, then this must
+/// be updated to reflect the maximum size of the CommBuffer that the implementation can tolerate.
+///
+/// Once inside of MM, the MM infrastructure will call all registered handlers with the same HandlerType as the GUID
+/// specified by HeaderGuid and the CommBuffer pointing to Data.
+///
+/// This function is not reentrant.
+///
+/// The standard header is used at the beginning of the EFI_MM_INITIALIZATION_HEADER structure during MM initialization.
+///
+///  @param this                The protocol instance.
+///  @param comm_buffer         A pointer to the buffer to convey into MMRAM.
+///  @param comm_size           The size of the data buffer being passed in. On exit, the size of data
+///                             being returned. Zero if the handler does not wish to reply with any data.
+///                             This parameter is optional and may be NULL.
+///
+///  @retval Status::SUCCESS           The message was successfully posted.
+///  @retval Status::INVALID_PARAMETER The comm_buffer pointer was NULL.
+///  @retval Status::BAD_BUFFER_SIZE   The buffer is too large for the MM implementation.
+///                                    If this error is returned, the MessageLength field
+///                                    in the comm_buffer header or the integer pointed by
+///                                    comm_size, are updated to reflect the maximum payload
+///                                    size the implementation can accommodate.
+///  @retval Status::ACCESS_DENIED     The CommunicateBuffer parameter or comm_size parameter,
+///                                    if not omitted, are in address range that cannot be
+///                                    accessed by the MM environment.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.9, Section IV-5.7.1
+pub type Communicate =
+    extern "efiapi" fn(this: *const Protocol, comm_buffer: *mut c_void, comm_size: usize) -> efi::Status;
+
+#[repr(C)]
+pub struct Protocol {
+    pub communicate: Communicate,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct EfiMmCommunicateHeader {
+    /// To avoid confusion in interpreting frames, the communication buffer should always begin with the header.
+    pub header_guid: r_efi::base::Guid,
+    /// Describes the size of Data (in bytes) and does not include the size of the header.
+    pub message_length: usize,
+    // Comm buffer data follows the header
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct EfiMmInitializationHeader {
+    /// To avoid confusion in interpreting frames, the communication buffer should always begin with the header.
+    pub comm_header: EfiMmCommunicateHeader,
+    /// Describes the size of Data (in bytes) and does not include the size of the header.
+    pub system_table: *mut system::SystemTable,
+}

--- a/src/protocols/communication2.rs
+++ b/src/protocols/communication2.rs
@@ -1,0 +1,63 @@
+//! Communication2 Protocol
+//!
+//! Provides a means of communicating between drivers outside of MM and MMI handlers inside of MM, in a way that hides
+//! the implementation details regarding whether traditional or standalone MM is being used.
+//!
+//! See <https://uefi.org/specs/PI/1.9/V4_UEFI_Protocols.html#efi-mm-communication2-protocol>
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+use core::ffi::c_void;
+use r_efi::efi;
+
+pub const PROTOCOL_GUID: efi::Guid =
+    efi::Guid::from_fields(0x378daedc, 0xf06b, 0x4446, 0x83, 0x14, &[0x40, 0xab, 0x93, 0x3c, 0x87, 0xa3]);
+
+/// Sends/receives a message for a registered handler.
+///
+/// This protocol provides runtime services for communicating between DXE drivers and a registered MMI handler.
+///
+/// Usage is identical to EFI_MM_COMMUNICATION_PROTOCOL.Communicate() except for the notes below:
+///
+/// - Instead of passing just the physical address via the comm_buffer parameter, the caller must pass both the physical
+///   and the virtual addresses of the communication buffer.
+///
+/// - If no virtual remapping has taken place, the physical address will be equal to the virtual address, and so the
+///   caller is required to pass the same value for both parameters.
+///
+///  @param this                       The protocol instance.
+///  @param comm_buffer_physical       Physical address of the buffer to convey into MMRAM.
+///  @param comm_buffer_virtual        Virtual address of the buffer to convey into MMRAM.
+///  @param comm_size                  The size of the data buffer being passed in. On exit, the size of data
+///                                    being returned. Zero if the handler does not wish to reply with any data.
+///                                    This parameter is optional and may be NULL.
+///
+///  @retval Status::SUCCESS           The message was successfully posted.
+///  @retval Status::INVALID_PARAMETER The comm_buffer parameters do not refer to the same location in memory.
+///  @retval Status::BAD_BUFFER_SIZE   The buffer is too large for the MM implementation.
+///                                    If this error is returned, the message_length field
+///                                    in the comm_buffer header or the integer pointed by
+///                                    comm_size, are updated to reflect the maximum payload
+///                                    size the implementation can accommodate.
+///  @retval Status::ACCESS_DENIED     The communicate buffer parameters or comm_size parameter,
+///                                    if not omitted, are in an address range that cannot be
+///                                    accessed by the MM environment.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.9, Section IV-5.7.4
+pub type Communicate2 = extern "efiapi" fn(
+    this: *const Protocol,
+    comm_buffer_physical: *mut c_void,
+    comm_buffer_virtual: *mut c_void,
+    comm_size: usize,
+) -> efi::Status;
+
+#[repr(C)]
+pub struct Protocol {
+    pub communicate2: Communicate2,
+}

--- a/src/protocols/communication3.rs
+++ b/src/protocols/communication3.rs
@@ -1,0 +1,85 @@
+//! Communication3 Protocol
+//!
+//! Provides a means of communicating between drivers outside of MM and MMI handlers inside of MM, for communication
+//! buffer that is compliant with EFI_MM_COMMUNICATE_HEADER_V3.
+//!
+//! See <https://uefi.org/specs/PI/1.9/V4_UEFI_Protocols.html#efi-mm-communication3-protocol>
+//!
+//! ## License
+//!
+//! Copyright (C) Microsoft Corporation. All rights reserved.
+//!
+//! SPDX-License-Identifier: BSD-2-Clause-Patent
+//!
+
+use core::ffi::c_void;
+use r_efi::efi;
+
+pub const PROTOCOL_GUID: efi::Guid =
+    efi::Guid::from_fields(0xf7234a14, 0x0df2, 0x46c0, 0xad, 0x28, &[0x90, 0xe6, 0xb8, 0x83, 0xa7, 0x2f]);
+
+pub const COMMUNICATE_HEADER_V3_GUID: efi::Guid =
+    efi::Guid::from_fields(0x68e8c853, 0x2ba9, 0x4dd7, 0x9a, 0xc0, &[0x91, 0xe1, 0x61, 0x55, 0xc9, 0x35]);
+
+/// Sends/receives a message for a registered handler.
+///
+/// This protocol provides runtime services for communicating between DXE drivers and a registered MMI handler.
+///
+/// Usage is similar to EFI_MM_COMMUNICATION_PROTOCOL.Communicate() except for the notes below:
+///
+/// - Communication buffer transfer to MM core should start with self::EfiMmCommunicateHeader.
+/// - With the updated header, the header_guid field is redefine as header GUID for MM core to differentiate the
+///   header format.
+/// - The message_guid field is moved to be after the header_guid field to allow for decent alignment and message
+///   disambiguation.
+/// - The message_data field is replaced with a flexible array to allow users not having to consume extra data
+///   during communicate.
+/// - Instead of passing just the physical address via the comm_buffer parameter, the caller must pass both the
+///   physical and the virtual addresses of the communication buffer.
+/// - If no virtual remapping has taken place, the physical address will be equal to the virtual address, and so the
+///   caller is required to pass the same value for both parameters.
+///
+///  @param this                       The protocol instance.
+///  @param comm_buffer_physical       Physical address of the buffer to convey into MMRAM, of which content must
+///                                    start with self::EfiMmCommunicateHeader.
+///  @param comm_buffer_virtual        Virtual address of the buffer to convey into MMRAM, of which content must
+///                                    start with self::EfiMmCommunicateHeader.
+///
+///  @retval Status::SUCCESS           The message was successfully posted.
+///  @retval Status::INVALID_PARAMETER comm_buffer_physical was null or comm_buffer_virtual was null.
+///  @retval Status::BAD_BUFFER_SIZE   The buffer is too large for the MM implementation.
+///                                    If this error is returned, the message_length field
+///                                    in the comm_buffer header, is updated to reflect the maximum payload
+///                                    size the implementation can accommodate.
+///  @retval Status::ACCESS_DENIED     The communicate buffer parameters are in an address range that cannot be
+///                                    accessed by the MM environment.
+///
+/// # Documentation
+/// UEFI Platform Initialization Specification, Release 1.9, Section IV-5.7.6
+pub type Communicate3 = extern "efiapi" fn(
+    this: *const Protocol,
+    comm_buffer_physical: *mut c_void,
+    comm_buffer_virtual: *mut c_void,
+) -> efi::Status;
+
+#[repr(C)]
+pub struct Protocol {
+    pub communicate3: Communicate3,
+}
+
+#[repr(C)]
+pub struct EfiMmCommunicateHeader {
+    /// Indicator GUID for MM core that the communication buffer is compliant with this v3 header.
+    /// Must be COMMUNICATE_HEADER_V3_GUID.
+    pub header_guid: efi::Guid,
+    /// This is technically a read-only field, which is described by the caller to indicate the size of the entire
+    /// buffer (in bytes) available for this communication transaction, including this communication header.
+    pub buffer_size: u64,
+    /// Reserved for future use.
+    pub reserved: u64,
+    /// Allows for disambiguation of the message format.
+    pub message_guid: efi::Guid,
+    /// Describes the size of MessageData (in bytes) and does not include the size of the header.
+    pub message_size: u64,
+    // Data follows the header that is message_size bytes in size.
+}


### PR DESCRIPTION
## Description

Closes #49 

Adds protocol definitions for:

- EFI_MM_COMMUNICATION_PROTOCOL
- EFI_MM_COMMUNICATION2_PROTOCOL
- EFI_MM_COMMUNICATION3_PROTOCOL

These provide a means of communicating between drivers outside of MM and MMI handlers inside of MM.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- `cargo build`, `cargo doc`, `cargo test`, `cargo fmt`, `cargo clippy`

## Integration Instructions

N/A - Normal protocol usage as needed.