### PR TITLE
rust-toolchain.toml: Add cargo-release

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,3 +4,4 @@ channel = "1.80.0"
 [tools]
 cargo-make = "0.37.24"
 cargo-tarpaulin = "0.31.5"
+cargo-release = "0.25.12"


### PR DESCRIPTION
## Description

cargo-release was removed during a file sync in de71243. It needs to be added back so the publish release workflow can download cargo-release.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- GitHub workflow on fork

## Integration Instructions

- N/A