### PR TITLE
Print the GUID for GUID HOBs

### DIFF
--- a/src/hob.rs
+++ b/src/hob.rs
@@ -1135,12 +1135,15 @@ impl fmt::Debug for HobList<'_> {
                     )?;
                 }
                 Hob::GuidHob(hob, _data) => {
+                    let (f0, f1, f2, f3, f4, &[f5, f6, f7, f8, f9, f10]) = hob.name.as_fields();
                     write!(
                         f,
                         indoc! {"
                         GUID HOB
-                          HOB Length: 0x{:x}\n"},
-                        hob.header.length
+                          Type: {:#x}
+                          Length: {:#x},
+                          GUID: {{{:08x}-{:04x}-{:04x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}}}\n"},
+                        hob.header.r#type, hob.header.length, f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10,
                     )?;
                 }
                 Hob::FirmwareVolume(hob) => {


### PR DESCRIPTION
## Description

Pretty print the GUID to make the HOB log info more useful.

Before:

```
GUID HOB
  HOB Length: 0xbb8
```

After:

```
GUID HOB
  Type: 0x4
  Length: 0xbb8,
  GUID: {3b387bfd-7abc-4cf2-a0ca-b6a16c1b1b25}
```

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- HOB dump in QEMU boot

## Integration Instructions

N/A