### PR TITLE
Align Capsule structure with UEFI_CAPSULE HOB structure definition

### DIFF
--- a/src/hob.rs
+++ b/src/hob.rs
@@ -628,7 +628,8 @@ pub struct Capsule {
     /// point to the base of the contiguous memory of the UEFI capsule.
     /// The length of the contiguous memory in bytes.
     ///
-    pub base_address: u64,
+    pub base_address: EfiPhysicalAddress,
+
     pub length: u64,
 }
 

--- a/src/hob.rs
+++ b/src/hob.rs
@@ -628,8 +628,8 @@ pub struct Capsule {
     /// point to the base of the contiguous memory of the UEFI capsule.
     /// The length of the contiguous memory in bytes.
     ///
-    pub base_address: u8,
-    pub length: u8,
+    pub base_address: u64,
+    pub length: u64,
 }
 
 /// Represents a HOB list.
@@ -924,7 +924,11 @@ impl<'a> HobList<'a> {
         fn assert_hob_size<T>(hob: &header::Hob) {
             let hob_len = hob.length as usize;
             let hob_size = mem::size_of::<T>();
-            assert_eq!(hob_len, hob_size, "Trying to cast hob of length {hob_len} into a pointer of size {hob_size}");
+            assert_eq!(
+                hob_len, hob_size,
+                "Trying to cast hob of length {hob_len} into a pointer of size {hob_size}. Hob type: {:?}",
+                hob.r#type
+            );
         }
 
         let mut hob_header: *const header::Hob = hob_list as *const header::Hob;


### PR DESCRIPTION
## Description

* Update the Capsule structure to properly align with the UEFI specification.
  * https://uefi.org/specs/PI/1.8A/V3_HOB_Code_Definitions.html#uefi-capsule-hob
* Add Hob Type print to alignment panic for easier debug.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

* Verified that the size comparision of a UEFI_CAPSULE hob no longer panics when casting the hob pointer.

## Integration Instructions

N/A