### PR TITLE
Make FFS spec members public.

### DIFF
--- a/src/fw_fs/ffs/file.rs
+++ b/src/fw_fs/ffs/file.rs
@@ -93,21 +93,21 @@ pub enum State {
 // EFI_FFS_FILE_HEADER
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct Header {
-    pub(crate) name: efi::Guid,
-    pub(crate) integrity_check_header: u8,
-    pub(crate) integrity_check_file: u8,
-    pub(crate) file_type: u8,
-    pub(crate) attributes: u8,
-    pub(crate) size: [u8; 3],
-    pub(crate) state: u8,
+pub struct Header {
+    pub name: efi::Guid,
+    pub integrity_check_header: u8,
+    pub integrity_check_file: u8,
+    pub file_type: u8,
+    pub attributes: u8,
+    pub size: [u8; 3],
+    pub state: u8,
 }
 
 // EFI_FFS_FILE_HEADER
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(dead_code)]
-pub(crate) struct Header2 {
-    pub(crate) header: Header,
-    pub(crate) extended_size: u64,
+pub struct Header2 {
+    pub header: Header,
+    pub extended_size: u64,
 }

--- a/src/fw_fs/fv.rs
+++ b/src/fw_fs/fv.rs
@@ -16,6 +16,9 @@ use r_efi::efi;
 
 pub type EfiFvFileType = u8;
 
+
+pub const FFS_REVISION: u8 = 2;
+
 /// Firmware Volume Write Policy bit definitions
 /// Note: Typically named `EFI_FV_*` in EDK II code.
 mod raw {
@@ -34,19 +37,19 @@ pub enum WritePolicy {
 
 /// EFI_FIRMWARE_VOLUME_HEADER
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Header {
-    pub(crate) zero_vector: [u8; 16],
-    pub(crate) file_system_guid: efi::Guid,
-    pub(crate) fv_length: u64,
-    pub(crate) signature: u32,
-    pub(crate) attributes: u32,
-    pub(crate) header_length: u16,
-    pub(crate) checksum: u16,
-    pub(crate) ext_header_offset: u16,
-    pub(crate) reserved: u8,
-    pub(crate) revision: u8,
-    pub(crate) block_map: [BlockMapEntry; 0],
+    pub zero_vector: [u8; 16],
+    pub file_system_guid: efi::Guid,
+    pub fv_length: u64,
+    pub signature: u32,
+    pub attributes: u32,
+    pub header_length: u16,
+    pub checksum: u16,
+    pub ext_header_offset: u16,
+    pub reserved: u8,
+    pub revision: u8,
+    pub block_map: [BlockMapEntry; 0],
 }
 
 #[repr(C)]
@@ -59,7 +62,7 @@ pub struct BlockMapEntry {
 /// EFI_FIRMWARE_VOLUME_EXT_HEADER
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct ExtHeader {
-    pub(crate) fv_name: efi::Guid,
-    pub(crate) ext_header_size: u32,
+pub struct ExtHeader {
+    pub fv_name: efi::Guid,
+    pub ext_header_size: u32,
 }

--- a/src/fw_fs/fv.rs
+++ b/src/fw_fs/fv.rs
@@ -18,6 +18,7 @@ pub type EfiFvFileType = u8;
 
 
 pub const FFS_REVISION: u8 = 2;
+pub const FFS_V2_MAX_FILE_SIZE: usize = 0x1000000;
 
 /// Firmware Volume Write Policy bit definitions
 /// Note: Typically named `EFI_FV_*` in EDK II code.

--- a/src/hob.rs
+++ b/src/hob.rs
@@ -776,7 +776,7 @@ impl<'a> HobList<'a> {
     ///     }
     /// }
     /// ```
-    pub fn iter(&self) -> impl Iterator<Item = &Hob> {
+    pub fn iter(&self) -> impl Iterator<Item = &Hob<'_>> {
         self.0.iter()
     }
 


### PR DESCRIPTION
## Description

Make PI spec structures for FFS public from `pub crate`.

Also includes a minor lint fix for HOB iter() API lifetime specification. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Passes unit tests, functional testing on hardware works.

## Integration Instructions

N/A