### PR TITLE
Mark as deprecated and bump version to 8.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "mu_pi"
-version = "7.0.0"
+version = "8.0.0"
 edition = "2024"
 license = "BSD-2-Clause-Patent"
-description = "Platform Initialization (PI) Specification definitions and support code in Rust."
+description = "DEPRECATED: Please use the patina crate instead. Platform Initialization (PI) Specification definitions and support code in Rust."
 repository = "https://github.com/microsoft/mu_rust_pi"
 readme = "README.md"
 rust-version = "1.85"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Mu Rust Platform Initialization (PI)
 
+> **DEPRECATED**: This repository has been deprecated. Most functionality has moved to the [patina](https://crates.io/crates/patina)
+> crate.
+
 Platform Initialization (PI) Specification definitions and support code in rust.
 
 This repository is part of [Project Mu](https://microsoft.github.io/mu).

--- a/examples/brotli.rs
+++ b/examples/brotli.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 extern crate mu_pi;
 use alloc_no_stdlib::{self, SliceWrapper, SliceWrapperMut, define_index_ops_mut};
 use brotli_decompressor::{BrotliDecompressStream, BrotliResult, BrotliState, HuffmanCode};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@
 //! reflect the degree of change.
 //!
 
+#![deprecated(since = "8.0.0", note = "This crate has been deprecated; please use the patina crate instead.")]
+#![allow(deprecated)]
 #![cfg_attr(not(test), no_std)]
 
 extern crate alloc;


### PR DESCRIPTION
## Description

Bumps the major version to indicate that this crate is no longer maintained. Applies the deprecated attribute so a warning is shown when the crate is used.

https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute

It is applied to the module, so all child items inherit the attribute.

The readme is updated to indicate deprecation as well. After this version is released, the GitHub repo will be archived.

The `allow(deprecated)` attribute is applied to the brotli.rs example and the lib.rs module to allow `cargo make all` to work.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- Do not use this crate any longer. In most cases equivalent functionality is available in the [patina](https://crates.io/crates/patina) crate.
